### PR TITLE
feat: feed SOUL.md + social-learning voice card to turn-taking/foresee

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -51,15 +51,40 @@ def _headers() -> Dict[str, str]:
     return {"Authorization": f"Bearer {_api_key()}", "Content-Type": "application/json"}
 
 
-def _persona(adapter: Any = None) -> Optional[str]:
-    """The bot's identity prompt, passed to the service so decide/naturalize speak
-    in the bot's voice.
+def _persona(adapter: Any = None, session_id: Optional[str] = None) -> Optional[str]:
+    """The bot's voice/style/personality, passed to the service so decide/
+    naturalize/foresee speak in the bot's voice.
 
-    Prefer the gateway's live value (reflects a runtime ``/personality`` change),
-    reached via the adapter's message handler; else fall back to the same sources
-    the gateway loads from: ``HERMES_EPHEMERAL_SYSTEM_PROMPT`` or
+    Only the persona parts of Hermes' system prompt — never tool/skill schemas:
+    ``SOUL.md`` (static personality) plus the social-learning voice card (the
+    live per-session voice). Falls back to the gateway live value (runtime
+    ``/personality`` change), ``HERMES_EPHEMERAL_SYSTEM_PROMPT``, or
     ``agent.system_prompt`` in ~/.hermes/config.yaml. None when unset (generic).
     """
+    # Voice/style/personality only: SOUL.md + the live voice card. Both are small
+    # persona text (no tool/skill schemas), so they stay under the service's
+    # agent_instructions cap. ponytail: SOUL.md read straight off disk like
+    # _HERMES_CONFIG; the card is read in-process from the social-learning plugin
+    # (both plugins share the one gateway process) — coupled to its _CACHE name,
+    # silently skipped if it moves.
+    parts: list[str] = []
+    try:
+        soul = _HERMES_CONFIG.with_name("SOUL.md").read_text().strip()
+        if soul:
+            parts.append(soul)
+    except Exception:
+        pass
+    if session_id:
+        try:
+            from hermes_plugins.social_learning import _CACHE  # noqa: PLC0415
+
+            card = _CACHE.get(session_id)
+            if card:
+                parts.append(card)
+        except Exception:
+            pass
+    if parts:
+        return "\n\n".join(parts)
     try:
         gw = getattr(getattr(adapter, "_message_handler", None), "__self__", None)
         live = getattr(gw, "_ephemeral_system_prompt", None)
@@ -524,7 +549,7 @@ async def _handle_inbound(self: Any, event: Any) -> None:
         if store is not None:
             session_id = store.get_or_create_session(source).session_id
             proceed = await _inbound_gate(
-                self, store, session_id, source.chat_id, [event], _persona(self)
+                self, store, session_id, source.chat_id, [event], _persona(self, session_id)
             )
         else:
             proceed = True  # no store → can't decide; fall back to normal dispatch
@@ -634,7 +659,7 @@ def on_transform_llm_output(response_text=None, session_id=None, **kwargs):
     # transform_llm_output runs in the agent's worker thread (no running loop here),
     # so hand _respond to the gateway loop captured on inbound. A bare create_task
     # raises "no running event loop" and the naturalize call is silently lost.
-    _coro = _respond(sid, draft, _persona(None))
+    _coro = _respond(sid, draft, _persona(None, sid))
     try:
         if _LOOP is not None:
             asyncio.run_coroutine_threadsafe(_coro, _LOOP)  # bubbles delivered via WS


### PR DESCRIPTION
## What

`_persona()` (the `system_prompt` the plugin sends to the turn-taking service's `decide`/`respond`, which the service forwards to theory-of-mind `foresee` as `agent_instructions`) now returns **only the persona parts** of Hermes' system prompt:

- **SOUL.md** — the static personality/voice/style file
- **social-learning voice card** — the live per-session voice (read in-process from the social-learning plugin's `_CACHE`)

Both call sites now pass `session_id` so the card can be looked up.

## Why

Before this, `_persona()` only read the gateway's ephemeral system prompt / env / `agent.system_prompt` — all empty in practice — so `foresee` received **no `agent_instructions`** and refined replies blind to the bot's voice (verified: 10/11 live foresee calls had no `AGENT INSTRUCTIONS` block).

The voice card lives only in the social-learning plugin's cache and is injected into the agent's own prompt as separate per-call context — it never reached the turn-taking path. This bridges that gap in-process (both plugins run in the one gateway process).

## Why not the whole system prompt

Investigated the full 17k-char assembled system prompt: it's ~SOUL.md + tool-use/execution directives + a large skills catalog. Hermes **deliberately** keeps STYLE/NORMS ("when to speak vs stay quiet", "response timing", verbosity, tone) **out** of the system prompt and delegates them to the social-learning layer. So the voice card is the real signal; forwarding the whole prompt would only add tool/skill noise and blow the service's `agent_instructions` cap. Hence: SOUL.md + card only.

## Behavior / safety

- Fail-open and unchanged fallbacks: if SOUL.md is missing *and* no card is cached, falls back to the previous gateway/env/config sources, else `None` (generic).
- Small payload by design — stays under the service's 8000-char `agent_instructions` cap.
- Couples to the social-learning plugin's `_CACHE` name; if that moves, the card is silently skipped (SOUL.md still flows).

## Companion change

The server side (turn-taking → theory-of-mind east-west, `agent_instructions` field + cap) is in humalike-v1 PR #119.