### PR TITLE
Feat/turn taking metadata roundtrip

### DIFF
--- a/TELEGRAM_GROUP_SETUP.md
+++ b/TELEGRAM_GROUP_SETUP.md
@@ -31,10 +31,15 @@ wtedy bot „widzi" wiadomość, ale nigdy nie odpowiada.
 - **Grupa (bez parowania każdej osoby):** autoryzuj **cały czat po ID** — wtedy
   każdy członek grupy działa automatycznie:
   ```
-  TELEGRAM_GROUP_ALLOWED_CHATS=<chat_id>      # np. -5359080915; * = wszystkie grupy
+  TELEGRAM_GROUP_ALLOWED_CHATS=<chat_id1>,<chat_id2>   # lista przecinkami; * = wszystkie grupy
   ```
   Chat_id grupy znajdziesz w logach gatewaya: `tt inbound: chat=<chat_id>`
   (grupy Telegrama mają ujemne ID).
+
+  ⚠️ **Każda grupa ma WŁASNY chat_id** — grupa z topikami (forum) to inny czat niż
+  zwykła grupa. Dodanie jednej nie autoryzuje drugiej; każdą nową grupę trzeba
+  dopisać do listy (przecinkami) i zrestartować gateway. Objaw pominięcia:
+  `Unauthorized user` mimo że „inna grupa działa".
 
   Alternatywy: `TELEGRAM_GROUP_ALLOWED_USERS=<id1>,<id2>` (tylko wymienione osoby),
   albo parowanie każdej osoby z osobna.
@@ -48,7 +53,8 @@ Sprawdź w logach: `✓ telegram connected` oraz `tt inbound / tt decide / tt fo
 
 ## Aktualna konfiguracja tego setupu
 - Bot: `t.me/minimiliani_bot`
-- Grupa autoryzowana: `TELEGRAM_GROUP_ALLOWED_CHATS=-5359080915`
+- Grupa autoryzowana: `TELEGRAM_GROUP_ALLOWED_CHATS=-1004418899432` (grupa z topikami;
+  zastąpiła starą `-5359080915`, którą przekonwertowano na forum)
 - DM: sparowany tylko właściciel (`hermes pairing list`)
 
 ## Szybka diagnoza „bot nie odpowiada w grupie"

--- a/TELEGRAM_GROUP_SETUP.md
+++ b/TELEGRAM_GROUP_SETUP.md
@@ -1,0 +1,58 @@
+# Hermes na Telegramie w grupie — checklista
+
+Wszystko, co trzeba zrobić, żeby bot (turn-taking) działał i odpowiadał ludziom
+w grupie. Ustawienia env trafiają do `~/.hermes/.env`; po zmianach **restart gatewaya**.
+
+## 1. Token bota
+1. W Telegramie napisz do **@BotFather** → `/newbot` (lub `/token` dla istniejącego).
+2. Skopiuj token → `~/.hermes/.env`:
+   ```
+   TELEGRAM_BOT_TOKEN=<token>
+   ```
+
+## 2. Wyłącz privacy mode (żeby bot widział WSZYSTKIE wiadomości grupy)
+Domyślnie bot w grupie dostaje tylko wiadomości, w których jest @wspomniany.
+Turn-taking musi widzieć wszystko, żeby decydować, kiedy się odezwać.
+1. @BotFather → `/setprivacy` → wybierz bota → **Disable**.
+2. **Usuń bota z grupy i dodaj ponownie** — zmiana privacy działa dopiero przy nowym członkostwie.
+
+## 3. Autoryzacja — kto dostaje odpowiedzi
+To OSOBNA warstwa od turn-taking. Turn-taking decyduje *czy* się odezwać, ale
+Hermes i tak odrzuca nieautoryzowanych nadawców (`Unauthorized user` w logach) —
+wtedy bot „widzi" wiadomość, ale nigdy nie odpowiada.
+
+- **DM:** każdy użytkownik musi być sparowany. Gdy ktoś napisze do bota, dostaje
+  kod; zatwierdzasz go:
+  ```
+  hermes pairing approve telegram <KOD>
+  ```
+  (lista: `hermes pairing list`, cofnięcie: `hermes pairing revoke`).
+
+- **Grupa (bez parowania każdej osoby):** autoryzuj **cały czat po ID** — wtedy
+  każdy członek grupy działa automatycznie:
+  ```
+  TELEGRAM_GROUP_ALLOWED_CHATS=<chat_id>      # np. -5359080915; * = wszystkie grupy
+  ```
+  Chat_id grupy znajdziesz w logach gatewaya: `tt inbound: chat=<chat_id>`
+  (grupy Telegrama mają ujemne ID).
+
+  Alternatywy: `TELEGRAM_GROUP_ALLOWED_USERS=<id1>,<id2>` (tylko wymienione osoby),
+  albo parowanie każdej osoby z osobna.
+
+## 4. Restart gatewaya
+```
+cd ~/repos/hermes-agent
+.venv/bin/hermes gateway run -v
+```
+Sprawdź w logach: `✓ telegram connected` oraz `tt inbound / tt decide / tt forward`.
+
+## Aktualna konfiguracja tego setupu
+- Bot: `t.me/minimiliani_bot`
+- Grupa autoryzowana: `TELEGRAM_GROUP_ALLOWED_CHATS=-5359080915`
+- DM: sparowany tylko właściciel (`hermes pairing list`)
+
+## Szybka diagnoza „bot nie odpowiada w grupie"
+1. **Brak `tt inbound` dla wiadomości** → privacy mode włączony (krok 2) lub bot nie jest w grupie.
+2. **Jest `tt decide ... stay_silent`** → turn-taking świadomie milczy (poprawne; odzywa się selektywnie).
+3. **`Unauthorized user: <id>` w logach** → nadawca nieautoryzowany (krok 3).
+4. **`tt respond ... DROPPED (superseded)`** → szybka seria wiadomości; dostarczana jest tylko najnowsza odpowiedź.

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,8 @@ from .turn_taking.patching import (
     _patch_merge_pending_message_event,
     _patch__poll_messages,
     _patch_send,
+    _patch_telegram_handle_message,
+    _patch_telegram_observe_group,
 )
 from .turn_taking.service import _service_url
 
@@ -66,6 +68,8 @@ def register(ctx) -> None:
     sent = _patch_send()
     inbound = _patch__enqueue_text_event()
     poll = _patch__poll_messages()
+    tg_media = _patch_telegram_handle_message()
+    tg_group = _patch_telegram_observe_group()
     merge_fix = _patch_merge_pending_message_event()
     hooked = False
     try:
@@ -73,5 +77,5 @@ def register(ctx) -> None:
         hooked = True
     except Exception as e:
         _log.warning("turn-taking: could not register transform_llm_output hook: %s", e)
-    _log.info("turn-taking registered (send=%s, inbound=%s, poll=%s, merge_fix=%s, transform=%s)",
-              sent, inbound, poll, merge_fix, hooked)
+    _log.info("turn-taking registered (send=%s, inbound=%s, poll=%s, tg_media=%s, tg_group=%s, merge_fix=%s, transform=%s)",
+              sent, inbound, poll, tg_media, tg_group, merge_fix, hooked)

--- a/tests/test_topic_metadata.py
+++ b/tests/test_topic_metadata.py
@@ -1,0 +1,77 @@
+"""Round-trip of the opaque per-turn delivery metadata (forum-topic placement).
+
+Checks the three ends of the metadata round-trip without a live service:
+  - decide side extracts the topic from event.source.thread_id (_delivery_meta),
+  - respond puts it in the wire body (service.respond),
+  - delivery hands it to send so the bubble lands in the topic (_forward).
+
+Run directly:  python3 tests/test_topic_metadata.py
+"""
+
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+
+# The repo dir name has hyphens (not a valid module name), and turn_taking/core
+# does `from .. import social_learning`, so it must load as a SUBpackage. Mount a
+# synthetic parent package rooted at the repo (same trick as test_to_messages.py).
+_ROOT = Path(__file__).resolve().parent.parent
+sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+_pkg = types.ModuleType("tt_pkg")
+_pkg.__path__ = [str(_ROOT)]
+sys.modules["tt_pkg"] = _pkg
+core = importlib.import_module("tt_pkg.turn_taking.core")
+state = importlib.import_module("tt_pkg.turn_taking.state")
+service = importlib.import_module("tt_pkg.turn_taking.service")
+delivery = importlib.import_module("tt_pkg.turn_taking.delivery")
+
+
+def _event(thread_id):
+    return types.SimpleNamespace(source=types.SimpleNamespace(thread_id=thread_id))
+
+
+def test_delivery_meta_reads_topic():
+    assert core._delivery_meta(_event("5")) == {"thread_id": "5"}
+    assert core._delivery_meta(_event(None)) == {}  # no topic → no hint
+    assert core._delivery_meta(_event(7)) == {"thread_id": "7"}  # coerced to str
+
+
+def test_respond_puts_metadata_in_body():
+    captured = {}
+
+    async def fake_post(path, body):
+        captured["body"] = body
+        return {"scheduled": []}
+
+    service._post = fake_post
+    asyncio.run(service.respond("tid", "hej", 7, None, {"thread_id": "5"}))
+    assert captured["body"]["metadata"] == {"thread_id": "5"}
+    captured.clear()
+    asyncio.run(service.respond("tid", "hej", 7, None, None))
+    assert "metadata" not in captured["body"]  # omitted when none
+
+
+def test_forward_passes_topic_to_send():
+    sent = {}
+
+    class FakeAdapter:
+        pass
+
+    async def fake_orig(adapter, chat_id, content, reply_to=None, metadata=None):
+        sent.update(chat_id=chat_id, content=content, metadata=metadata)
+
+    adapter = FakeAdapter()
+    state.ORIG_SEND[FakeAdapter] = fake_orig
+    state.ROUTES["T1"] = (adapter, "-100grp")
+    asyncio.run(delivery._forward("T1", "bubble", {"thread_id": "5"}))
+    assert sent == {"chat_id": "-100grp", "content": "bubble", "metadata": {"thread_id": "5"}}
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok {name}")
+    print("all passed")

--- a/turn_taking/core.py
+++ b/turn_taking/core.py
@@ -73,6 +73,18 @@ def _build_system_prompt_for_turn_taking(adapter: Any = None, session_id: Option
         return None
 
 
+def _delivery_meta(event: Any) -> Dict[str, str]:
+    """Opaque per-turn delivery hints to round-trip through respond → bubble.
+
+    Currently just the forum-topic id: Telegram sets ``source.thread_id`` for forum
+    topics (and the General-topic sentinel), and its ``send`` places a bubble in a
+    topic via ``metadata["thread_id"]``. Empty for non-topic chats and WhatsApp
+    groups (no ``thread_id``), so delivery is unchanged there.
+    """
+    tid = getattr(getattr(event, "source", None), "thread_id", None)
+    return {"thread_id": str(tid)} if tid else {}
+
+
 # ── Decide gate: submit a batch, decide, stash the speak epoch ────────────────
 async def _decide(
     session_id: str,
@@ -81,6 +93,7 @@ async def _decide(
     messages: list[Dict[str, str]],
     system_prompt: Optional[str] = None,
     message_id: str = "",
+    delivery_meta: Optional[Dict[str, str]] = None,
 ) -> Optional[str]:
     """Submit a batch and return the decision ("speak" / "stay_silent").
 
@@ -102,6 +115,8 @@ async def _decide(
         # the turn then degrades to a plain (un-naturalized) reply rather than risk a
         # mismatched epoch. WhatsApp always carries one, so this is the rare path.
         state.EPOCH_BY_MESSAGE_ID[message_id] = epoch
+        if delivery_meta:
+            state.META_BY_MESSAGE_ID[message_id] = delivery_meta
     _log.info("tt decide: session=%s chat=%s mid=%s decision=%s epoch=%s",
               session_id, chat_id, message_id, decision, epoch)
     return decision
@@ -109,7 +124,8 @@ async def _decide(
 
 # ── Respond side: naturalize a draft, carry this turn's epoch ──────────────────
 async def _respond(
-    session_id: str, draft: str, epoch: Optional[int], system_prompt: Optional[str] = None
+    session_id: str, draft: str, epoch: Optional[int], system_prompt: Optional[str] = None,
+    metadata: Optional[Dict[str, str]] = None,
 ) -> bool:
     """Naturalize a completed draft using THIS turn's epoch (resolved by the
     transform hook from the per-turn message_id) and call respond. In WS mode the
@@ -125,7 +141,7 @@ async def _respond(
         return False  # this session never decided speak
     _log.info("tt respond: session=%s tid=%s epoch=%s → naturalizing | %r",
               session_id, tid, epoch, (draft or "").strip()[:60])
-    res = await respond(tid, draft, epoch, system_prompt)
+    res = await respond(tid, draft, epoch, system_prompt, metadata)
     if not res or res.get("superseded"):
         _log.info("tt respond: session=%s → DROPPED (superseded=%s / no response)",
                   session_id, bool(res and res.get("superseded")))
@@ -178,7 +194,10 @@ async def _inbound_gate(
     messages = _to_messages(events)
     if not messages:
         return True  # nothing to decide → let Hermes handle it
-    decision = await _decide(session_id, adapter, chat_id, messages, system_prompt, message_id)
+    delivery_meta = _delivery_meta(events[-1]) if events else {}
+    decision = await _decide(
+        session_id, adapter, chat_id, messages, system_prompt, message_id, delivery_meta
+    )
     if decision == "stay_silent":
         _persist_observed(session_store, session_id, events)
         _log.info("tt gate: session=%s chat=%s → STAY_SILENT (persisted %d observed msg(s), no dispatch)",

--- a/turn_taking/delivery.py
+++ b/turn_taking/delivery.py
@@ -23,8 +23,15 @@ def _set_route(thread_id: str, adapter: Any, chat_id: str) -> None:
     state.ROUTES[thread_id] = (adapter, chat_id)
 
 
-async def _forward(thread_id: Optional[str], content: Optional[str]) -> None:
-    """on_message callback: route one delivered bubble to its WhatsApp chat.
+async def _forward(
+    thread_id: Optional[str], content: Optional[str], metadata: Optional[dict] = None
+) -> None:
+    """on_message callback: route one delivered bubble to its chat.
+
+    ``metadata`` is the service's verbatim echo of the respond's metadata — here the
+    forum-topic id ({"thread_id": ...}), passed straight to ``send`` so the bubble
+    lands in the source topic (Telegram reads ``metadata["thread_id"]``; WhatsApp
+    ignores it). None/empty → normal placement.
 
     No route (e.g. after a restart lost the map) → log + drop, never crash the
     receive loop.
@@ -37,15 +44,16 @@ async def _forward(thread_id: Optional[str], content: Optional[str]) -> None:
         return
     adapter, chat_id = route
     orig = state.ORIG_SEND.get(type(adapter))
-    _log.info("tt forward: tid=%s chat=%s → deliver bubble (via=%s) | %r",
-              thread_id, chat_id, "orig" if orig is not None else "plain", content[:60])
+    _log.info("tt forward: tid=%s chat=%s → deliver bubble (via=%s, topic=%s) | %r",
+              thread_id, chat_id, "orig" if orig is not None else "plain",
+              (metadata or {}).get("thread_id"), content[:60])
     # Deliver via this adapter class's original send so the bubble bypasses our
     # patch (which drops the agent's draft). Before _patch_send runs, adapter.send
-    # IS the original.
+    # IS the original. Pass metadata so a forum-topic bubble lands in its topic.
     if orig is not None:
-        await orig(adapter, chat_id, content)
+        await orig(adapter, chat_id, content, metadata=metadata or None)
     else:
-        await adapter.send(chat_id, content)
+        await adapter.send(chat_id, content, metadata=metadata or None)
 
 
 async def _forward_typing(thread_id: Optional[str], is_typing: Optional[bool]) -> None:

--- a/turn_taking/delivery.py
+++ b/turn_taking/delivery.py
@@ -36,12 +36,14 @@ async def _forward(thread_id: Optional[str], content: Optional[str]) -> None:
         _log.warning("turn-taking: no route for thread %s — dropping bubble", thread_id)
         return
     adapter, chat_id = route
+    orig = state.ORIG_SEND.get(type(adapter))
     _log.info("tt forward: tid=%s chat=%s → deliver bubble (via=%s) | %r",
-              thread_id, chat_id, "orig" if state.ORIG_SEND is not None else "plain", content[:60])
-    # Deliver via the original send so the bubble bypasses our patch (which drops
-    # the agent's draft). Before _patch_send runs, adapter.send IS the original.
-    if state.ORIG_SEND is not None:
-        await state.ORIG_SEND(adapter, chat_id, content)
+              thread_id, chat_id, "orig" if orig is not None else "plain", content[:60])
+    # Deliver via this adapter class's original send so the bubble bypasses our
+    # patch (which drops the agent's draft). Before _patch_send runs, adapter.send
+    # IS the original.
+    if orig is not None:
+        await orig(adapter, chat_id, content)
     else:
         await adapter.send(chat_id, content)
 

--- a/turn_taking/hooks.py
+++ b/turn_taking/hooks.py
@@ -52,6 +52,7 @@ def on_transform_llm_output(response_text=None, session_id=None, **kwargs):
     # per-task contextvar, looked up in the map filled at decide). consume once.
     mid = _current_message_id()
     epoch = state.EPOCH_BY_MESSAGE_ID.pop(mid, None) if mid else None
+    meta = state.META_BY_MESSAGE_ID.pop(mid, None) if mid else None
     if not draft or epoch is None:
         return None  # not a turn-taking speak turn → leave Hermes alone
     chat = _chat_for_session(sid)
@@ -62,7 +63,7 @@ def on_transform_llm_output(response_text=None, session_id=None, **kwargs):
     # transform_llm_output runs in the agent's worker thread (no running loop here),
     # so hand _respond to the gateway loop captured on inbound. A bare create_task
     # raises "no running event loop" and the naturalize call is silently lost.
-    _coro = _respond(sid, draft, epoch, _build_system_prompt_for_turn_taking(None, sid))
+    _coro = _respond(sid, draft, epoch, _build_system_prompt_for_turn_taking(None, sid), meta)
     try:
         if state.LOOP is not None:
             asyncio.run_coroutine_threadsafe(_coro, state.LOOP)  # bubbles delivered via WS

--- a/turn_taking/patching.py
+++ b/turn_taking/patching.py
@@ -13,7 +13,7 @@ import logging
 from typing import Any, Callable
 
 from . import state
-from .core import _inbound_gate, _build_system_prompt_for_turn_taking, _decide
+from .core import _inbound_gate, _build_system_prompt_for_turn_taking, _decide, _delivery_meta
 from .service import _to_messages
 
 _log = logging.getLogger("hermes.plugins.turn_taking")
@@ -282,6 +282,7 @@ async def _handle_observed_group(self: Any, event: Any, replay: Callable[[], Any
                 decision = await _decide(
                     session_id, self, source.chat_id, messages,
                     _build_system_prompt_for_turn_taking(self, session_id), message_id,
+                    _delivery_meta(event),
                 )
         except Exception as e:
             _log.warning("turn-taking observed-group gate failed: %s", e)

--- a/turn_taking/patching.py
+++ b/turn_taking/patching.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Callable
 
 from . import state
-from .core import _inbound_gate, _build_system_prompt_for_turn_taking
+from .core import _inbound_gate, _build_system_prompt_for_turn_taking, _decide
+from .service import _to_messages
 
 _log = logging.getLogger("hermes.plugins.turn_taking")
 
@@ -21,50 +22,76 @@ _reply_anchor_patched = False  # idempotency for _patch__reply_anchor_for_event
 _merge_patched = False  # idempotency for _patch_merge_pending_message_event
 
 
-# ── Hermes wiring: monkeypatch WhatsAppAdapter.send ───────────────────────────
+def _platform_adapter_classes() -> list:
+    """The adapter classes turn-taking patches, those importable in this gateway.
+
+    Each platform is imported independently so a build without one (e.g. no
+    Telegram deps) just skips it. Both inherit ``BasePlatformAdapter`` and share
+    the ``send`` / ``_enqueue_text_event`` surface, so the same wrappers fit both.
+    """
+    classes = []
+    try:
+        from gateway.platforms.whatsapp import WhatsAppAdapter
+        classes.append(WhatsAppAdapter)
+    except Exception as e:
+        _log.warning("turn-taking: WhatsAppAdapter unavailable: %s", e)
+    try:
+        from gateway.platforms.telegram import TelegramAdapter
+        classes.append(TelegramAdapter)
+    except Exception as e:
+        _log.warning("turn-taking: TelegramAdapter unavailable: %s", e)
+    return classes
+
+
+# ── Hermes wiring: monkeypatch each adapter's send ────────────────────────────
 def _patch_send() -> bool:
-    """Wrap ``WhatsAppAdapter.send``: turn the agent's draft into bubbles.
+    """Wrap each platform adapter's ``send``: turn the agent's draft into bubbles.
 
     When ``send`` carries the agent's reply for a "speak" turn, naturalize it
     (``_respond`` → bubbles delivered over WS) INSTEAD of sending the raw draft —
     that avoids the duplicate (whole draft + its split bubbles). Everything else
-    passes straight through: errors, command replies, and — via ``_ORIG_SEND`` —
-    the bubbles themselves.
+    passes straight through: errors, command replies, and — via
+    ``state.ORIG_SEND`` — the bubbles themselves.
 
-    The "this is the draft" signal is ``_PENDING_ANSWERS`` (keyed by exact answer
+    The "this is the draft" signal is ``PENDING_ANSWERS`` (keyed by exact answer
     text), registered by the transform hook for the answer it naturalized; the send
     whose content matches is dropped, so a racing tool-notice can't be consumed by
-    mistake. The draft still reaches Hermes history (persisted before send). Idempotent.
+    mistake. The draft still reaches Hermes history (persisted before send).
+
+    Patches every importable adapter class, each wrapper closing over its OWN
+    class's original via a factory so a Telegram bubble is never sent through
+    WhatsApp's send and vice versa. Idempotent.
     """
-    try:
-        from gateway.platforms.whatsapp import WhatsAppAdapter
-    except Exception as e:
-        _log.warning("turn-taking: cannot patch send (no WhatsAppAdapter): %s", e)
-        return False
-    if getattr(WhatsAppAdapter.send, "_tt_patched", False):
-        return False  # already patched
-    _orig = WhatsAppAdapter.send
-    state.ORIG_SEND = _orig  # so _forward can deliver bubbles via the genuine send
+    patched_any = False
+    for cls in _platform_adapter_classes():
+        if getattr(cls.send, "_tt_patched", False):
+            continue
+        _orig = cls.send
+        state.ORIG_SEND[cls] = _orig  # so _forward delivers bubbles via the genuine send
 
-    async def _send(self, chat_id, content, reply_to=None, metadata=None):
-        pend = state.PENDING_ANSWERS.get(chat_id)
-        key = (content or "").strip()
-        if pend is not None and key in pend:
-            pend.discard(key)
-            if not pend:
-                state.PENDING_ANSWERS.pop(chat_id, None)
-            # This send IS the agent's final answer — naturalized by
-            # transform_llm_output and delivered as bubbles over WS, so drop the
-            # raw copy. Empty content → original returns a no-send success.
-            _log.info("tt send: chat=%s → SUPPRESS (matched answer, bubbles via WS) | %r",
-                      chat_id, key[:50])
-            return await _orig(self, chat_id, "", reply_to=reply_to, metadata=metadata)
-        _log.info("tt send: chat=%s → passthrough | %r", chat_id, key[:50])
-        return await _orig(self, chat_id, content, reply_to=reply_to, metadata=metadata)
+        def _make_send(orig):
+            async def _send(self, chat_id, content, reply_to=None, metadata=None):
+                pend = state.PENDING_ANSWERS.get(chat_id)
+                key = (content or "").strip()
+                if pend is not None and key in pend:
+                    pend.discard(key)
+                    if not pend:
+                        state.PENDING_ANSWERS.pop(chat_id, None)
+                    # This send IS the agent's final answer — naturalized by
+                    # transform_llm_output and delivered as bubbles over WS, so drop
+                    # the raw copy. Empty content → original returns a no-send success.
+                    _log.info("tt send: chat=%s → SUPPRESS (matched answer, bubbles via WS) | %r",
+                              chat_id, key[:50])
+                    return await orig(self, chat_id, "", reply_to=reply_to, metadata=metadata)
+                _log.info("tt send: chat=%s → passthrough | %r", chat_id, key[:50])
+                return await orig(self, chat_id, content, reply_to=reply_to, metadata=metadata)
+            return _send
 
-    _send._tt_patched = True  # type: ignore[attr-defined]
-    WhatsAppAdapter.send = _send
-    return True
+        _send = _make_send(_orig)
+        _send._tt_patched = True  # type: ignore[attr-defined]
+        cls.send = _send
+        patched_any = True
+    return patched_any
 
 
 # ── Inbound patch: gate each message, no debounce ─────────────────────────────
@@ -100,26 +127,34 @@ async def _handle_inbound(self: Any, event: Any) -> None:
         _log.warning("turn-taking inbound gate failed: %s", e)
         proceed = True  # fail-open
     if proceed:
-        await self.handle_message(event)
+        # Dispatch a "speak" turn through the GENUINE handler. On a platform whose
+        # handle_message is gated (Telegram, for media), self.handle_message is our
+        # gate — calling it would recurse; ORIG_HANDLE holds the real one. WhatsApp
+        # has no entry (its handle_message is unpatched) → use it directly.
+        orig = state.ORIG_HANDLE.get(type(self))
+        if orig is not None:
+            await orig(self, event)
+        else:
+            await self.handle_message(event)
 
 
 def _patch__enqueue_text_event() -> bool:
-    """Replace ``WhatsAppAdapter._enqueue_text_event``: gate each message instead
-    of Hermes's 5s merge-debounce. Idempotent. Returns True if patched."""
-    try:
-        from gateway.platforms.whatsapp import WhatsAppAdapter
-    except Exception as e:
-        _log.warning("turn-taking: cannot patch inbound (no WhatsAppAdapter): %s", e)
-        return False
-    if getattr(WhatsAppAdapter._enqueue_text_event, "_tt_patched", False):
-        return False
+    """Replace each adapter's ``_enqueue_text_event``: gate each message instead
+    of Hermes's merge-debounce. Patches every importable adapter class (the gate is
+    platform-agnostic — it duck-types the event). Idempotent. Returns True if any
+    class was patched."""
+    patched_any = False
+    for cls in _platform_adapter_classes():
+        if getattr(cls._enqueue_text_event, "_tt_patched", False):
+            continue
 
-    def _enqueue_text_event(self, event):
-        asyncio.create_task(_handle_inbound(self, event))
+        def _enqueue_text_event(self, event):
+            asyncio.create_task(_handle_inbound(self, event))
 
-    _enqueue_text_event._tt_patched = True  # type: ignore[attr-defined]
-    WhatsAppAdapter._enqueue_text_event = _enqueue_text_event
-    return True
+        _enqueue_text_event._tt_patched = True  # type: ignore[attr-defined]
+        cls._enqueue_text_event = _enqueue_text_event
+        patched_any = True
+    return patched_any
 
 
 def _patch__poll_messages() -> bool:
@@ -183,6 +218,117 @@ def _patch__poll_messages() -> bool:
 
     _poll_messages._tt_patched = True  # type: ignore[attr-defined]
     WhatsAppAdapter._poll_messages = _poll_messages
+    return True
+
+
+# ── Telegram media gate: route handle_message through the turn-taking gate ─────
+def _patch_telegram_handle_message() -> bool:
+    """Gate Telegram media by routing ``TelegramAdapter.handle_message`` through the
+    same gate as text.
+
+    Telegram text is gated at ``_enqueue_text_event``, but media
+    (photos/voice/docs/video) is dispatched straight to ``handle_message``, so it
+    would bypass turn-taking. Wrapping ``handle_message`` sends every such event
+    through ``_handle_inbound``; the genuine handler is captured in
+    ``state.ORIG_HANDLE`` so a "speak" turn dispatches via it instead of recursing.
+
+    Telegram-only: WhatsApp routes media through the patched ``_poll_messages``
+    loop, so its ``handle_message`` stays unpatched (and ``_handle_inbound`` falls
+    back to it directly). Idempotent.
+    """
+    try:
+        from gateway.platforms.telegram import TelegramAdapter
+    except Exception as e:
+        _log.warning("turn-taking: cannot patch Telegram media gate (no TelegramAdapter): %s", e)
+        return False
+    if getattr(TelegramAdapter.handle_message, "_tt_patched", False):
+        return False
+    _orig = TelegramAdapter.handle_message  # inherited from base; genuine handler
+    state.ORIG_HANDLE[TelegramAdapter] = _orig
+
+    async def handle_message(self, event):
+        await _handle_inbound(self, event)
+
+    handle_message._tt_patched = True  # type: ignore[attr-defined]
+    TelegramAdapter.handle_message = handle_message
+    return True
+
+
+# ── Group observation gate: let turn-taking jump into unmentioned chatter ──────
+async def _handle_observed_group(self: Any, event: Any, replay: Callable[[], Any]) -> None:
+    """Gate one unmentioned group message: dispatch on an explicit "speak",
+    otherwise fall back to the genuine observe (``replay``) so it's persisted as
+    context.
+
+    Fail-CLOSED on purpose (unlike the DM gate, which fails open to a reply):
+    anything but an explicit "speak" — stay_silent OR service unavailable — routes
+    to observe, so a down turn-taking service can't make the bot answer every group
+    message. Correlation/epoch are stashed by ``_decide`` exactly as on the DM path.
+    """
+    try:
+        state.LOOP = asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    _patch__reply_anchor_for_event(self)
+    message_id = str(getattr(event, "message_id", "") or "")
+    source = event.source
+    decision = None
+    store = getattr(self, "_session_store", None)
+    if store is not None:
+        try:
+            session_id = store.get_or_create_session(source).session_id
+            messages = _to_messages([event])
+            if messages:
+                decision = await _decide(
+                    session_id, self, source.chat_id, messages,
+                    _build_system_prompt_for_turn_taking(self, session_id), message_id,
+                )
+        except Exception as e:
+            _log.warning("turn-taking observed-group gate failed: %s", e)
+            decision = None
+    _log.info("tt group-observe: chat=%s mid=%s decision=%s",
+              getattr(source, "chat_id", None), message_id, decision)
+    if decision == "speak":
+        orig = state.ORIG_HANDLE.get(type(self))
+        if orig is not None:
+            await orig(self, event)
+        else:
+            await self.handle_message(event)
+    else:
+        replay()  # genuine observe: persist as context (fail-closed)
+
+
+def _patch_telegram_observe_group() -> bool:
+    """Route unmentioned Telegram group messages through the turn-taking gate.
+
+    ``_observe_unmentioned_group_message`` is the single funnel every untriggered
+    group message (text/media/location) reaches. Wrapping it lets turn-taking
+    decide to jump in unprompted (speak → dispatch) while keeping the original
+    silent-observe behaviour for everything else. Telegram-only; idempotent.
+
+    ponytail: gating observed chatter opens a turn-taking thread per active group
+    even when the bot mostly stays silent — the cost of "see everything". If that
+    bites in busy groups, gate thread-open on a cheaper pre-check.
+    """
+    try:
+        from gateway.platforms.telegram import TelegramAdapter
+    except Exception as e:
+        _log.warning("turn-taking: cannot patch Telegram group observe (no TelegramAdapter): %s", e)
+        return False
+    if getattr(TelegramAdapter._observe_unmentioned_group_message, "_tt_patched", False):
+        return False
+    _orig = TelegramAdapter._observe_unmentioned_group_message
+
+    def _observe(self, message, msg_type, update_id=None, event=None):
+        try:
+            ev = event or self._build_message_event(message, msg_type, update_id=update_id)
+        except Exception:
+            return _orig(self, message, msg_type, update_id=update_id, event=event)
+        replay = lambda: _orig(self, message, msg_type, update_id=update_id, event=ev)
+        asyncio.create_task(_handle_observed_group(self, ev, replay))
+
+    _observe._tt_patched = True  # type: ignore[attr-defined]
+    TelegramAdapter._observe_unmentioned_group_message = _observe
     return True
 
 

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -113,11 +113,19 @@ async def respond(
     content: str,
     turn_epoch: int,
     system_prompt: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Naturalize a draft (epoch required, fail-closed). Returns {scheduled, superseded}."""
+    """Naturalize a draft (epoch required, fail-closed). Returns {scheduled, superseded}.
+
+    ``metadata`` is an opaque per-turn bag the service echoes verbatim on every
+    delivered bubble frame (svc contract ``RespondRequest.metadata``, cap 4 KB) —
+    used here to carry the forum-topic id to ``_forward``.
+    """
     body: Dict[str, Any] = {"thread_id": thread_id, "content": content, "turn_epoch": turn_epoch}
     if system_prompt:
         body["system_prompt"] = system_prompt[:_SYSTEM_PROMPT_CAP]
+    if metadata:
+        body["metadata"] = metadata
     return await _post(RESPOND_PATH, body)
 
 
@@ -137,12 +145,13 @@ def _connect_url(open_resp: Optional[Dict[str, Any]]) -> Optional[str]:
 
 async def _receive_loop(
     connect_url: str,
-    on_message: Callable[[Optional[str], Optional[str]], Awaitable[None]],
+    on_message: Callable[[Optional[str], Optional[str], Optional[Dict[str, Any]]], Awaitable[None]],
     on_typing: Optional[Callable[[Optional[str], Optional[bool]], Awaitable[None]]] = None,
 ) -> None:
     """Read envelopes until the socket closes; dispatch each by ``type``.
 
-    - ``turn_taking.message`` → ``await on_message(thread_id, content)`` (one bubble)
+    - ``turn_taking.message`` → ``await on_message(thread_id, content, metadata)`` (one bubble;
+      ``metadata`` is the verbatim echo of the respond's ``metadata``, or None)
     - ``turn_taking.typing``  → ``await on_typing(thread_id, typing)`` (if provided)
     - ``attached`` (handshake) → ignored
 
@@ -166,7 +175,7 @@ async def _receive_loop(
                 data = env.get("data") or {}
                 _log.info("tt ws: frame type=%s tid=%s", t, data.get("thread_id"))
                 if t == "turn_taking.message":
-                    await on_message(data.get("thread_id"), data.get("content"))
+                    await on_message(data.get("thread_id"), data.get("content"), data.get("metadata"))
                 elif t == "turn_taking.typing" and on_typing is not None:
                     await on_typing(data.get("thread_id"), data.get("typing"))
     except Exception as e:

--- a/turn_taking/state.py
+++ b/turn_taking/state.py
@@ -48,6 +48,14 @@ OPEN_LOCK = asyncio.Lock()     # serializes thread-opens (rare) so a burst can't
 # copy_context). That is ordering-independent and needs no interrupt to stay correct.
 EPOCH_BY_MESSAGE_ID: Dict[str, int] = {}  # message_id → turn_epoch of the "speak" decision
 
+# Per-turn opaque delivery hints, keyed by the same message_id as the epoch above
+# and with the same lifecycle (stashed at decide on "speak", popped by the transform
+# hook). Round-tripped through the service's respond.metadata → echoed verbatim on
+# every delivered bubble frame → read by delivery._forward. First use: the Telegram
+# forum-topic id ({"thread_id": ...}) so a bubble lands in the source topic, not
+# General. Empty/absent for non-topic chats and WhatsApp.
+META_BY_MESSAGE_ID: Dict[str, Dict[str, str]] = {}
+
 # Per-turn RAW message_id, carried into the turn's worker thread and read by the
 # transform hook. Bound as a side effect of GatewayRunner._reply_anchor_for_event
 # (see _patch__reply_anchor_for_event), NOT in the inbound task: a queued message's

--- a/turn_taking/state.py
+++ b/turn_taking/state.py
@@ -20,10 +20,20 @@ from typing import Any, Callable, Dict, Optional, Tuple
 # thread_id → (adapter, chat_id): where to deliver this thread's bubbles.
 ROUTES: Dict[str, Tuple[Any, str]] = {}
 
-# The genuine adapter.send, captured before patching, so _forward delivers
-# bubbles via the ORIGINAL — they bypass our patch entirely, which is what
-# suppresses the agent's monolithic draft. No metadata marker needed.
-ORIG_SEND: Optional[Callable] = None
+# The genuine adapter.send per adapter class, captured before patching, so
+# _forward delivers bubbles via the ORIGINAL — they bypass our patch entirely,
+# which is what suppresses the agent's monolithic draft. No metadata marker needed.
+# Keyed by adapter class so WhatsApp and Telegram can be patched at once without a
+# single global clobbering one platform's original with the other's.
+ORIG_SEND: Dict[type, Callable] = {}
+
+# The genuine adapter.handle_message per adapter class, captured before patching
+# handle_message to gate media. Only platforms whose handle_message is gated have
+# an entry; _handle_inbound dispatches a "speak" turn through this genuine handler
+# (so it doesn't recurse into the gate). No entry (e.g. WhatsApp, whose media goes
+# through the patched _poll loop, not a gated handle_message) → _handle_inbound
+# falls back to the adapter's own (unpatched) handle_message.
+ORIG_HANDLE: Dict[type, Callable] = {}
 
 # ── Session → thread map: one thread per conversation ─────────────────────────
 SESSIONS: Dict[str, str] = {}  # Hermes session_id → turn-taking thread_id


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Telegram group support for Hermes turn-taking, including better handling for forum/topic chats.
  * Replies can now stay within the correct Telegram topic/thread when available.
  * Expanded support for preserving response context across the delivery flow.

* **Documentation**
  * Added a Telegram setup checklist with configuration, restart, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->