### PR TITLE
Add Slack support

### DIFF
--- a/SLACK_GROUP_SETUP.md
+++ b/SLACK_GROUP_SETUP.md
@@ -1,0 +1,110 @@
+# Hermes on Slack in a channel — checklist
+
+How to make the bot (turn-taking) see EVERY message in a channel, not just
+ones with an @mention. Settings go in `~/.hermes/config.yaml` (the `slack:`
+section) or `~/.hermes/.env`; **restart the gateway** after changing them.
+
+## Important: this is a config-only workaround, not a real "observe"
+
+Unlike Telegram, Slack has **no** separate "overhear but don't reply" path
+(`_observe_unmentioned_group_message`). Slack only has one gate: a message
+either gets processed and reaches `handle_message` (i.e. our turn-taking gate,
+`_handle_inbound`), or no `MessageEvent` is ever built for it at all.
+
+Our turn-taking gate (`_handle_inbound`) is **fail-open** — designed for
+messages explicitly directed at the bot (DM / @mention): if the turn-taking
+service goes down, the bot replies anyway (the safe default when someone is
+addressing it directly). Enabling the config below means EVERY message in the
+channel (even ones never meant for the bot) goes through that same fail-open
+gate.
+
+**Consequence:** if the turn-taking service (`service_url`) becomes
+unreachable or errors out, the bot will start replying to EVERYTHING in that
+channel, not just messages directed at it. That's a deliberate tradeoff — a
+real fail-closed "observe" (like Telegram has) would require a host-side
+change (`plugins/platforms/slack/adapter.py`), see the `hermes-agent`
+conversation from 2026-07-01. For a small, trusted channel this risk is
+usually acceptable.
+
+## 1. Two SEPARATE gates — both must be opened for "everyone, every channel"
+
+Slack authorization is checked BEFORE the mention gate, in a different layer
+(`gateway/authz_mixin.py`). A message from an unauthorized user never reaches
+turn-taking at all — it's dropped with `Unauthorized user: <id> on slack` in
+the logs, before `handle_message` is even called. Opening only the mention
+gate (below) still leaves the bot deaf to anyone not explicitly authorized.
+
+**Gate A — authorization (who is allowed to talk to the bot at all):**
+```
+SLACK_ALLOWED_USERS=<user_id1>,<user_id2>   # default: only these users
+# or, to let EVERYONE in the workspace through:
+SLACK_ALLOW_ALL_USERS=true
+```
+
+**Gate B — the @mention requirement (only applies to channels, not DMs):**
+
+Option A — whole bot, all channels:
+```
+SLACK_REQUIRE_MENTION=false
+```
+
+Option B — only specific channels (safer):
+```
+SLACK_FREE_RESPONSE_CHANNELS=<channel_id1>,<channel_id2>
+```
+`require_mention` stays enabled everywhere else; only the listed channels get
+"free response". Find the channel ID in the gateway logs after the first
+message from that channel, or in Slack's URL (`.../C0123456789/...`).
+
+Equivalent in `~/.hermes/config.yaml`:
+```yaml
+slack:
+  require_mention: false          # gate B, option A
+  # or:
+  free_response_channels:         # gate B, option B
+    - "C0123456789"
+```
+
+**For "every message from everyone, bot decides" (no scoping):**
+```
+SLACK_ALLOW_ALL_USERS=true
+SLACK_REQUIRE_MENTION=false
+```
+Both env vars, no channel/user whitelist. This is genuinely open — any Slack
+user, in any channel the bot is in, on every message — combined with the
+fail-open turn-taking gate (see "Important" above), so weigh that before
+flipping it bot-wide on a busy/public workspace.
+
+## 2. (Optional) restrict to trusted channels
+
+If using option A (global disable), consider also adding a whitelist so the
+bot doesn't start free-responding in every channel it gets added to:
+```
+SLACK_ALLOWED_CHANNELS=<channel_id1>,<channel_id2>
+```
+
+## 3. Restart the gateway
+```
+cd ~/repos/hermes-agent
+.venv/bin/hermes gateway run -v
+```
+Check the logs for: `[Slack] Socket Mode connected` and `tt inbound / tt decide / tt forward`
+for messages without an @mention in the configured channel.
+
+## Quick diagnosis: "bot doesn't see messages without a mention"
+
+0. **`Unauthorized user: <id> on slack` in the logs** → gate A (above), not
+   gate B — the message never reached turn-taking at all. Add the user to
+   `SLACK_ALLOWED_USERS` or set `SLACK_ALLOW_ALL_USERS=true`.
+1. **No `tt inbound` for an unmentioned message (and no "Unauthorized user"
+   line either)** → gate B — `require_mention` is still `true` for that
+   channel (check option A/B above), or the channel isn't in
+   `free_response_channels`.
+2. **`Ignoring message in non-allowed channel` in the logs** → the channel
+   isn't in `SLACK_ALLOWED_CHANNELS` (the whitelist blocks it even with
+   `require_mention` disabled).
+3. **`tt decide ... stay_silent` shows up** → turn-taking is deliberately
+   staying quiet (expected — it decides selectively, same as Telegram groups).
+4. **Bot replies to everything when the turn-taking service is down** → this
+   is the expected behavior of this workaround (see "Important" above), not
+   a bug.

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,7 @@ from .turn_taking.patching import (
     _patch_merge_pending_message_event,
     _patch__poll_messages,
     _patch_send,
+    _patch_slack_handle_message,
     _patch_telegram_handle_message,
     _patch_telegram_observe_group,
 )
@@ -70,6 +71,7 @@ def register(ctx) -> None:
     poll = _patch__poll_messages()
     tg_media = _patch_telegram_handle_message()
     tg_group = _patch_telegram_observe_group()
+    slack = _patch_slack_handle_message()
     merge_fix = _patch_merge_pending_message_event()
     hooked = False
     try:
@@ -77,5 +79,5 @@ def register(ctx) -> None:
         hooked = True
     except Exception as e:
         _log.warning("turn-taking: could not register transform_llm_output hook: %s", e)
-    _log.info("turn-taking registered (send=%s, inbound=%s, poll=%s, tg_media=%s, tg_group=%s, merge_fix=%s, transform=%s)",
-              sent, inbound, poll, tg_media, tg_group, merge_fix, hooked)
+    _log.info("turn-taking registered (send=%s, inbound=%s, poll=%s, tg_media=%s, tg_group=%s, slack=%s, merge_fix=%s, transform=%s)",
+              sent, inbound, poll, tg_media, tg_group, slack, merge_fix, hooked)

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -60,3 +60,9 @@ Restart the Hermes gateway so the plugin and its `/soul enhance` command registe
   first-startup auto-enhance) does anything — a bare template is skipped.
 - Disable the one-time auto-enhance with `soul_auto_enhance: false` or env
   `HERMES_SOUL_AUTO_ENHANCE=false`.
+- Telegram group chats need privacy mode disabled so the bot sees every
+  message, not just @mentions — see `TELEGRAM_GROUP_SETUP.md`.
+- Slack channels only see @mentions/DMs by default too (no equivalent of
+  Telegram's `_observe_unmentioned_group_message` on the host today) — for a
+  config-only workaround (with its fail-open caveat), see
+  `SLACK_GROUP_SETUP.md`.

--- a/turn_taking/patching.py
+++ b/turn_taking/patching.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from typing import Any, Callable
 
 from . import state
@@ -22,24 +23,53 @@ _reply_anchor_patched = False  # idempotency for _patch__reply_anchor_for_event
 _merge_patched = False  # idempotency for _patch_merge_pending_message_event
 
 
+def _real_adapter_class(platform: str, class_name: str):
+    """The adapter class the GATEWAY actually uses for *platform*.
+
+    Hermes loads bundled platform adapters (plugins/platforms/<platform>/adapter.py)
+    through its dynamic plugin loader under the synthetic module name
+    ``hermes_plugins.<platform>_platform.adapter`` (see hermes_cli/plugins.py's
+    ``_load_directory_module``), NOT via a plain ``import
+    plugins.platforms.<platform>.adapter``. The plain import still "succeeds" (the
+    file is on a real, walkable package path) but re-executes the module under a
+    SEPARATE sys.modules key, producing a second, distinct class object that the
+    live gateway never instantiates — patching it is a silent no-op.
+
+    Going through ``platform_registry.get(platform)`` forces its deferred loader
+    to resolve (importing the real module, if not already loaded) so we can then
+    pull the actual class out of ``sys.modules`` under the name the gateway uses.
+    Safe to call from plugin ``register()``: bundled platform manifests are
+    discovered before user plugins, so the deferred loader is already registered
+    by the time this runs.
+    """
+    from gateway.platform_registry import platform_registry
+
+    platform_registry.get(platform)  # force-resolve the deferred loader
+    module_name = f"hermes_plugins.{platform}_platform.adapter"
+    module = sys.modules.get(module_name)
+    cls = getattr(module, class_name, None) if module is not None else None
+    if cls is None:
+        raise ImportError(f"{class_name} not found in {module_name}")
+    return cls
+
+
 def _platform_adapter_classes() -> list:
     """The adapter classes turn-taking patches, those importable in this gateway.
 
-    Each platform is imported independently so a build without one (e.g. no
-    Telegram deps) just skips it. Both inherit ``BasePlatformAdapter`` and share
-    the ``send`` / ``_enqueue_text_event`` surface, so the same wrappers fit both.
+    Each platform is resolved independently so a build without one (e.g. no
+    Telegram deps) just skips it. All three inherit ``BasePlatformAdapter`` and
+    share the ``send`` surface, so the same wrapper fits every one.
     """
     classes = []
-    try:
-        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
-        classes.append(WhatsAppAdapter)
-    except Exception as e:
-        _log.warning("turn-taking: WhatsAppAdapter unavailable: %s", e)
-    try:
-        from plugins.platforms.telegram.adapter import TelegramAdapter
-        classes.append(TelegramAdapter)
-    except Exception as e:
-        _log.warning("turn-taking: TelegramAdapter unavailable: %s", e)
+    for platform, class_name in (
+        ("whatsapp", "WhatsAppAdapter"),
+        ("telegram", "TelegramAdapter"),
+        ("slack", "SlackAdapter"),
+    ):
+        try:
+            classes.append(_real_adapter_class(platform, class_name))
+        except Exception as e:
+            _log.warning("turn-taking: %s unavailable: %s", class_name, e)
     return classes
 
 
@@ -57,6 +87,14 @@ def _patch_send() -> bool:
     text), registered by the transform hook for the answer it naturalized; the send
     whose content matches is dropped, so a racing tool-notice can't be consumed by
     mistake. The draft still reaches Hermes history (persisted before send).
+
+    A suppressed send returns a synthetic success directly — it never calls the
+    real ``send``. WhatsApp/Telegram happen to no-op empty content themselves
+    (an early-return before any formatting/API call), but Slack's ``send`` has no
+    such guard: an empty ``chat.postMessage`` errors, which trips the host's
+    plain-text-fallback retry (``_send_with_retry``) and re-sends the very draft
+    we were suppressing. Not calling ``orig`` at all sidesteps that regardless of
+    whether a given platform happens to have an empty-content guard.
 
     Patches every importable adapter class, each wrapper closing over its OWN
     class's original via a factory so a Telegram bubble is never sent through
@@ -79,10 +117,12 @@ def _patch_send() -> bool:
                         state.PENDING_ANSWERS.pop(chat_id, None)
                     # This send IS the agent's final answer — naturalized by
                     # transform_llm_output and delivered as bubbles over WS, so drop
-                    # the raw copy. Empty content → original returns a no-send success.
+                    # the raw copy. Synthetic success — never touches the real send,
+                    # so no platform's API can reject it (see docstring).
                     _log.info("tt send: chat=%s → SUPPRESS (matched answer, bubbles via WS) | %r",
                               chat_id, key[:50])
-                    return await orig(self, chat_id, "", reply_to=reply_to, metadata=metadata)
+                    from gateway.platforms.base import SendResult
+                    return SendResult(success=True)
                 _log.info("tt send: chat=%s → passthrough | %r", chat_id, key[:50])
                 return await orig(self, chat_id, content, reply_to=reply_to, metadata=metadata)
             return _send
@@ -145,8 +185,9 @@ def _patch__enqueue_text_event() -> bool:
     class was patched."""
     patched_any = False
     for cls in _platform_adapter_classes():
-        if getattr(cls._enqueue_text_event, "_tt_patched", False):
-            continue
+        orig = getattr(cls, "_enqueue_text_event", None)
+        if orig is None or getattr(orig, "_tt_patched", False):
+            continue  # e.g. Slack, which has no _enqueue_text_event split (see _patch_slack_handle_message)
 
         def _enqueue_text_event(self, event):
             asyncio.create_task(_handle_inbound(self, event))
@@ -174,7 +215,7 @@ def _patch__poll_messages() -> bool:
     connect and start this task (run.py:4535).
     """
     try:
-        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+        WhatsAppAdapter = _real_adapter_class("whatsapp", "WhatsAppAdapter")
     except Exception as e:
         _log.warning("turn-taking: cannot patch poll loop (no WhatsAppAdapter): %s", e)
         return False
@@ -237,7 +278,7 @@ def _patch_telegram_handle_message() -> bool:
     back to it directly). Idempotent.
     """
     try:
-        from plugins.platforms.telegram.adapter import TelegramAdapter
+        TelegramAdapter = _real_adapter_class("telegram", "TelegramAdapter")
     except Exception as e:
         _log.warning("turn-taking: cannot patch Telegram media gate (no TelegramAdapter): %s", e)
         return False
@@ -251,6 +292,36 @@ def _patch_telegram_handle_message() -> bool:
 
     handle_message._tt_patched = True  # type: ignore[attr-defined]
     TelegramAdapter.handle_message = handle_message
+    return True
+
+
+# ── Slack gate: route handle_message through the turn-taking gate ─────────────
+def _patch_slack_handle_message() -> bool:
+    """Gate Slack by routing ``SlackAdapter.handle_message`` through the same
+    gate as Telegram media.
+
+    Slack has no ``_enqueue_text_event`` split — every inbound event (text,
+    files, slash commands) funnels through the single inherited
+    ``handle_message`` (adapter.py's ``_handle_slack_message`` /
+    ``_handle_slack_file_shared`` / ``_handle_slash_command`` all call it), so
+    one patch covers everything, mirroring ``_patch_telegram_handle_message``.
+    Idempotent.
+    """
+    try:
+        SlackAdapter = _real_adapter_class("slack", "SlackAdapter")
+    except Exception as e:
+        _log.warning("turn-taking: cannot patch Slack gate (no SlackAdapter): %s", e)
+        return False
+    if getattr(SlackAdapter.handle_message, "_tt_patched", False):
+        return False
+    _orig = SlackAdapter.handle_message  # inherited from base; genuine handler
+    state.ORIG_HANDLE[SlackAdapter] = _orig
+
+    async def handle_message(self, event):
+        await _handle_inbound(self, event)
+
+    handle_message._tt_patched = True  # type: ignore[attr-defined]
+    SlackAdapter.handle_message = handle_message
     return True
 
 
@@ -312,7 +383,7 @@ def _patch_telegram_observe_group() -> bool:
     bites in busy groups, gate thread-open on a cheaper pre-check.
     """
     try:
-        from plugins.platforms.telegram.adapter import TelegramAdapter
+        TelegramAdapter = _real_adapter_class("telegram", "TelegramAdapter")
     except Exception as e:
         _log.warning("turn-taking: cannot patch Telegram group observe (no TelegramAdapter): %s", e)
         return False


### PR DESCRIPTION
## Summary
- Adds a Slack gate (`_patch_slack_handle_message`, mirroring the existing Telegram media-gate pattern) and registers `SlackAdapter` alongside WhatsApp/Telegram in `_platform_adapter_classes()`.
- Fixes a module-identity bug that silently broke turn-taking on **all three platforms** (not just Slack): adapter classes are now resolved via `gateway.platform_registry` instead of a plain `import plugins.platforms.<platform>.adapter`, which was re-executing the host's adapter modules under a separate `sys.modules` key and patching a phantom copy the live gateway never used.
- Fixes send suppression to return a synthetic `SendResult(success=True)` instead of calling the real `send()` with empty content — Slack's `send()` has no empty-content guard (unlike WhatsApp/Telegram), so an empty send errored and tripped the host's plain-text-fallback retry, duplicating every reply.
- Documents Slack channel access config (`SLACK_GROUP_SETUP.md`) — the two separate access gates (authorization vs @mention requirement), a config-only workaround for "every message from everyone" with its fail-open caveat, and diagnosis steps.

## Test plan
- [x] Verified adapter class identity offline against the host's real plugin-loading mechanism (`hermes_plugins.<platform>_platform.adapter`), confirming the patched class matches what the live gateway instantiates for all three platforms.
- [x] Verified live end-to-end against a real Hermes gateway + Slack workspace: `tt inbound` → `tt decide` → `tt send SUPPRESS` → `tt forward` (naturalized bubbles) fire correctly for real Slack messages, with no duplicate "(Response formatting failed, plain text:)" messages.
- [x] Confirmed WhatsApp/Telegram gating still works unaffected by the registry-based resolution change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slack channel setup guidance for receiving messages without `@mentions`, including configuration options and expected behavior.

* **Bug Fixes**
  * Improved message handling across Slack, Telegram, and WhatsApp so turn-taking and inbound processing work more reliably.
  * Reduced duplicate or unintended replies by handling suppressed draft messages more safely.

* **Documentation**
  * Updated installation notes with platform-specific tips for Telegram privacy mode and Slack channel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->