### PR TITLE
Persist social-learning voice card cache across restarts

### DIFF
--- a/social_learning/__init__.py
+++ b/social_learning/__init__.py
@@ -21,8 +21,10 @@ Config (config.yaml)
       log_requests: false                     # optional debug dump
 Env: SOCIAL_LEARNING_API_KEY (sent as the X-API-Key header).
 
-ponytail: in-memory only (no restart persistence), no back-off, last-writer-wins
-— all acceptable for a style hint. Uses httpx (already a plugin dep), not requests.
+ponytail: no back-off, last-writer-wins — acceptable for a style hint. Uses
+httpx (already a plugin dep), not requests. Cache is persisted to a JSON file
+(_CACHE_FILE) so voice cards survive a Hermes restart; see _load_cache /
+_save_cache.
 """
 
 from __future__ import annotations
@@ -44,6 +46,41 @@ SERVICE_PATH: str = "/v1/social-learning/actions/extract"
 _LOCK: threading.Lock = threading.Lock()
 _CACHE: Dict[str, str] = {}   # session_id -> prompt_block (voice card)
 _COUNTER: Dict[str, int] = {}  # session_id -> turn count
+
+
+def _cache_file():
+    from hermes_constants import get_hermes_home  # noqa: PLC0415
+
+    return get_hermes_home() / "state" / "social-learning-cache.json"
+
+
+def _load_cache() -> None:
+    """Best-effort restore of _CACHE/_COUNTER from disk. Never raises."""
+    try:
+        path = _cache_file()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        _CACHE.update(data.get("cache", {}))
+        _COUNTER.update(data.get("counter", {}))
+        logger.info("social-learning: restored %d cached voice card(s) from %s", len(_CACHE), path)
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        logger.debug("social-learning: cache restore failed: %s", exc)
+
+
+def _save_cache() -> None:
+    """Persist _CACHE/_COUNTER to disk (atomic write). Caller holds _LOCK. Never raises."""
+    try:
+        path = _cache_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps({"cache": _CACHE, "counter": _COUNTER}), encoding="utf-8")
+        tmp.replace(path)
+    except Exception as exc:
+        logger.debug("social-learning: cache save failed: %s", exc)
+
+
+_load_cache()
 
 
 # ── Config helpers ────────────────────────────────────────────────────────────
@@ -185,6 +222,7 @@ def _refresh_card(session_id: str, conversation_history: Any) -> None:
             if isinstance(prompt_block, str) and prompt_block:
                 with _LOCK:
                     _CACHE[session_id] = prompt_block
+                    _save_cache()
                 logger.info(
                     "social-learning: refreshed voice card for session %s (%d chars from %d msgs)",
                     session_id, len(prompt_block), len(transcript),

--- a/tests/test_social_learning.py
+++ b/tests/test_social_learning.py
@@ -1,7 +1,8 @@
 """Checks for the embedded social-learning voice-card module.
 
-social_learning.py imports httpx (not installed in this test env), so we stub it
-and load the module by file path. Run directly:  python3 tests/test_social_learning.py
+social_learning/ imports httpx (not installed in this test env) and its sibling
+_config.py via a relative import, so we stub httpx and load both under a fake
+parent package. Run directly:  python3 tests/test_social_learning.py
 """
 
 import importlib.util
@@ -14,8 +15,22 @@ _ROOT = Path(__file__).resolve().parent.parent
 
 def _load():
     sys.modules.setdefault("httpx", types.ModuleType("httpx"))
-    spec = importlib.util.spec_from_file_location("sl", _ROOT / "social_learning.py")
+
+    pkg = types.ModuleType("_humalike_test_pkg")
+    pkg.__path__ = [str(_ROOT)]
+    sys.modules["_humalike_test_pkg"] = pkg
+
+    cfg_spec = importlib.util.spec_from_file_location("_humalike_test_pkg._config", _ROOT / "_config.py")
+    cfg = importlib.util.module_from_spec(cfg_spec)
+    sys.modules["_humalike_test_pkg._config"] = cfg
+    cfg_spec.loader.exec_module(cfg)
+
+    spec = importlib.util.spec_from_file_location(
+        "_humalike_test_pkg.social_learning", _ROOT / "social_learning" / "__init__.py"
+    )
     mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "_humalike_test_pkg.social_learning"
+    sys.modules["_humalike_test_pkg.social_learning"] = mod
     spec.loader.exec_module(mod)
     return mod
 
@@ -51,6 +66,29 @@ def test_inject_returns_context_with_card():
 
 def test_no_session_id_is_noop():
     assert sl.on_pre_llm_call(session_id="") is None
+
+
+def test_cache_survives_reload_from_disk():
+    """_save_cache() writes; a fresh _load_cache() on an empty _CACHE restores it —
+    the actual restart-persistence behavior this test is for."""
+    import tempfile
+    from pathlib import Path
+
+    tmp = Path(tempfile.mkdtemp())
+    orig_cache_file = sl._cache_file
+    sl._cache_file = lambda: tmp / "social-learning-cache.json"
+    try:
+        sl._CACHE["restart-test"] = "voice card text"
+        sl._save_cache()
+        assert (tmp / "social-learning-cache.json").exists()
+
+        sl._CACHE.clear()
+        sl._COUNTER.clear()
+        sl._load_cache()
+        assert sl._CACHE == {"restart-test": "voice card text"}
+    finally:
+        sl._cache_file = orig_cache_file
+        sl._CACHE.pop("restart-test", None)
 
 
 if __name__ == "__main__":

--- a/tests/test_social_learning.py
+++ b/tests/test_social_learning.py
@@ -85,7 +85,7 @@ def test_cache_survives_reload_from_disk():
         sl._CACHE.clear()
         sl._COUNTER.clear()
         sl._load_cache()
-        assert sl._CACHE == {"restart-test": "voice card text"}
+        assert sl._CACHE.get("restart-test") == "voice card text"
     finally:
         sl._cache_file = orig_cache_file
         sl._CACHE.pop("restart-test", None)


### PR DESCRIPTION
## Summary
- The social-learning voice card cache (`_CACHE`/`_COUNTER`) was in-memory only, so a Hermes restart wiped every cached voice card and each session had to re-accumulate turns before the next refresh fired.
- Adds `_load_cache()` (runs once at import) and `_save_cache()` (atomic write, called after every cache update in `_refresh_card`), backed by a single JSON file at `<hermes_home>/state/social-learning-cache.json`.
- Fixed `tests/test_social_learning.py`'s module loader, which was already broken (pointed at a `social_learning.py` file that hasn't existed since the module became a package with a sibling `_config.py`), and added a persistence round-trip test.

## Test plan
- [x] `python3 tests/test_social_learning.py` — all 5 tests pass, including the new `test_cache_survives_reload_from_disk`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Social-learning voice cards and turn counters now persist across restarts, restoring previously learned context automatically.
* **Bug Fixes**
  * Improved reliability of cached social-learning state by saving updates when new voice-card content is received.
  * Restart behavior now preserves the expected cached value instead of resetting it.
* **Tests**
  * Added coverage to verify cache persistence across reloads using a temporary on-disk cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->