### PR TITLE
Platform config warnings (one-time) + voice-card warm-up at startup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,6 +14,7 @@ This module only registers the plugin's command, hooks, and patches.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from pathlib import Path
@@ -35,21 +36,36 @@ from .turn_taking.service import _service_url
 _log = logging.getLogger(__name__)
 
 
-_TRUE = {"true", "1", "yes", "on"}
+# The host's truthy set for allow-all/enabled flags is exactly this — no "on"
+# (slack/whatsapp adapters use `in {"true", "1", "yes"}`). _FALSE matches the
+# host's require_mention parse (`not in {"false", "0", "no", "off"}`).
+_HOST_TRUE = {"true", "1", "yes"}
 _FALSE = {"false", "0", "no", "off"}
 
 
+def _sections(cfg, name):
+    """Every yaml spot the host reads a platform section from: top-level
+    ``<name>:``, ``platforms.<name>:`` and ``gateway.platforms.<name>:``."""
+    c = cfg if isinstance(cfg, dict) else {}
+    for holder in (c, c.get("platforms"), (c.get("gateway") or {}).get("platforms")):
+        sec = holder.get(name) if isinstance(holder, dict) else None
+        if isinstance(sec, dict):
+            yield sec
+
+
 def _resolve(env_key: str, cfg, section: str, cfg_key: str):
-    """A platform setting as the host resolves it: env var wins, else the
-    ``config.yaml`` platform-section key, else None. Checking both keeps us from
-    warning about something the operator set in yaml instead of env."""
+    """A platform setting as the host resolves it: adapters read their yaml
+    section (``config.extra``) before env, so yaml wins here too. Lists join
+    to CSV exactly like the host's yaml→env bridges do."""
+    for sec in _sections(cfg, section):
+        v = sec.get(cfg_key)
+        if v is None or v == "":
+            continue
+        if isinstance(v, list):
+            return ",".join(str(x) for x in v)
+        return str(v)
     v = os.environ.get(env_key)
-    if v not in (None, ""):
-        return v
-    sec = (cfg or {}).get(section) or {}
-    if isinstance(sec, dict) and sec.get(cfg_key) not in (None, ""):
-        return str(sec.get(cfg_key))
-    return None
+    return v if v not in (None, "") else None
 
 
 def _platform_config_problems(cfg) -> list:
@@ -65,28 +81,43 @@ def _platform_config_problems(cfg) -> list:
     if env.get("TELEGRAM_BOT_TOKEN"):
         raw = _resolve("TELEGRAM_GROUP_ALLOWED_CHATS", cfg, "telegram", "group_allowed_chats") or ""
         chats = [c.strip() for c in raw.split(",") if c.strip()]
-        users = _resolve("TELEGRAM_GROUP_ALLOWED_USERS", cfg, "telegram", "group_allowed_users")
-        if not chats and not users:
-            out.append("Telegram: no group authorized (TELEGRAM_GROUP_ALLOWED_CHATS empty) — the bot "
-                       "IGNORES every group message. Add the group's chat id (negative) or '*'.")
+        if not chats:
+            # User-level allowlists don't substitute: group OBSERVATION (what
+            # turn-taking runs on) requires an explicit chat allowlist in the
+            # host — with only user auth the bot answers direct @mentions but
+            # never sees the group's conversation stream.
+            out.append("Telegram: TELEGRAM_GROUP_ALLOWED_CHATS is empty — the bot cannot observe "
+                       "group conversation, so group turn-taking is OFF (at most it answers direct "
+                       "@mentions from allowed users). Add each group's chat id (negative, e.g. -100…).")
         for c in chats:
-            if c != "*" and not (c.startswith("-") and c[1:].isdigit()):
-                out.append(f"Telegram: TELEGRAM_GROUP_ALLOWED_CHATS entry '{c}' is not a group id "
-                           "(group ids are negative, e.g. -100…) — that entry authorizes nothing.")
+            if not (c.startswith("-") and c[1:].isdigit()):
+                out.append(f"Telegram: TELEGRAM_GROUP_ALLOWED_CHATS entry '{c}' is not a group id — "
+                           "Hermes matches chat ids literally ('*' does not work here; group ids are "
+                           "negative, e.g. -100…), so that entry authorizes nothing.")
 
-    # ── Slack (in use if a token is set) ──
+    # ── Slack (in use if a token is set; user auth is env-only in the host) ──
     if env.get("SLACK_BOT_TOKEN") or env.get("SLACK_APP_TOKEN"):
-        if env.get("SLACK_ALLOW_ALL_USERS", "").lower() not in _TRUE and not env.get("SLACK_ALLOWED_USERS", "").strip():
-            out.append("Slack: no user authorized — the bot IGNORES everyone. "
-                       "Set SLACK_ALLOW_ALL_USERS=true, or list SLACK_ALLOWED_USERS.")
+        allow_all = any(env.get(k, "").strip().lower() in _HOST_TRUE
+                        for k in ("SLACK_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS"))
+        listed = env.get("SLACK_ALLOWED_USERS", "").strip() or env.get("GATEWAY_ALLOWED_USERS", "").strip()
+        if not allow_all and not listed:
+            out.append("Slack: no user authorized — the bot ignores everyone except already-paired "
+                       "users. Set SLACK_ALLOW_ALL_USERS=true, or list SLACK_ALLOWED_USERS.")
+        for k in ("SLACK_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS"):
+            v = env.get(k, "").strip().lower()
+            if v and v not in _HOST_TRUE and v not in _FALSE:
+                out.append(f"Slack: {k}='{v}' is not a value Hermes accepts (true/1/yes) — "
+                           "it is treated as OFF.")
         mention = (_resolve("SLACK_REQUIRE_MENTION", cfg, "slack", "require_mention") or "").lower()
         free = _resolve("SLACK_FREE_RESPONSE_CHANNELS", cfg, "slack", "free_response_channels")
         if mention not in _FALSE and not free:
             out.append("Slack: the bot only replies when @mentioned in channels. Set "
                        "SLACK_REQUIRE_MENTION=false (or SLACK_FREE_RESPONSE_CHANNELS) to answer unmentioned messages.")
 
-    # ── WhatsApp (in use if any WHATSAPP_* var is set) ──
-    if any(k.startswith("WHATSAPP_") for k in env):
+    # ── WhatsApp (in use only when the host would enable it: WHATSAPP_ENABLED
+    # truthy — WHATSAPP_ENABLED=false or WHATSAPP_CLOUD_* alone don't count) ──
+    wa_enabled = (_resolve("WHATSAPP_ENABLED", cfg, "whatsapp", "enabled") or "").strip().lower()
+    if wa_enabled in _HOST_TRUE:
         policy = (_resolve("WHATSAPP_GROUP_POLICY", cfg, "whatsapp", "group_policy") or "").lower()
         if policy and policy not in {"open", "allowlist", "disabled", "pairing"}:
             out.append(f"WhatsApp: WHATSAPP_GROUP_POLICY='{policy}' is not valid "
@@ -101,19 +132,38 @@ def _platform_config_problems(cfg) -> list:
     return out
 
 
-def _should_chat_warn() -> bool:
-    """Chat-warn about config exactly ONCE ever (until the marker file is
-    removed), then never again — a deliberate setup shouldn't be nagged for
-    eternity. Only called when there ARE problems, so the marker is written the
-    first time we'd actually warn. Logs still fire every boot regardless."""
-    marker = Path.home() / ".hermes" / ".turn_taking_config_warned"
-    if marker.exists():
-        return False
+def _marker_path() -> Path:
+    """Chat-warn marker in the real hermes home (HERMES_HOME-aware); falls
+    back to ~/.hermes when hermes_constants isn't importable."""
     try:
-        marker.write_text("1")
+        from hermes_constants import get_hermes_home  # noqa: PLC0415
+        return Path(get_hermes_home()) / ".turn_taking_config_warned"
+    except Exception:
+        return Path.home() / ".hermes" / ".turn_taking_config_warned"
+
+
+def _should_chat_warn(digest: str) -> bool:
+    """Chat-warn once per distinct problem set: the marker holds the digest of
+    the problems that were actually DELIVERED to a home chat (see
+    _mark_chat_warned). The same set stays silent — a deliberate setup isn't
+    nagged — but any new or changed problem warns again. Logs still fire every
+    boot regardless."""
+    try:
+        return _marker_path().read_text().strip() != digest
+    except Exception:
+        return True
+
+
+def _mark_chat_warned(digest: str) -> None:
+    """Delivery callback from notify: record WHAT was warned about, only once
+    the message really reached a home chat. Queued-but-undelivered warnings
+    (URL unset, CLI process, no /sethome yet) keep re-queueing until seen."""
+    try:
+        p = _marker_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(digest)
     except Exception:
         pass  # best-effort; worst case the warning repeats, never lost
-    return True
 
 
 def _warn_misconfig() -> None:
@@ -121,8 +171,10 @@ def _warn_misconfig() -> None:
     answer nowhere. Two families: plugin-core (URL/key/streaming/group_sessions
     — the plugin can't work) and per-platform auth/mention (it connects but
     ignores messages). Logged in full on every start; pushed to the home chat
-    only the FIRST time (see _should_chat_warn), so a deliberate setup isn't
-    nagged forever. URL-unset stays log-only (no inbound path to flush).
+    once per distinct problem set, and only counted as warned when actually
+    delivered (see _should_chat_warn/_mark_chat_warned). While URL is unset the
+    push stays queued (no inbound path installs), so it arrives — not is lost —
+    once the plugin is configured.
     """
     problems = []
     if not _config.service_url():
@@ -151,8 +203,13 @@ def _warn_misconfig() -> None:
     problems += _platform_config_problems(cfg)
     for p in problems:
         _log.warning("turn-taking: %s", p)
-    if problems and _should_chat_warn():
-        notify.queue_startup("⚠️ turn-taking / platform config:\n• " + "\n• ".join(problems))
+    if problems:
+        digest = hashlib.sha256("\n".join(sorted(problems)).encode()).hexdigest()
+        if _should_chat_warn(digest):
+            notify.queue_startup(
+                "⚠️ turn-taking / platform config:\n• " + "\n• ".join(problems),
+                on_delivered=lambda: _mark_chat_warned(digest),
+            )
 
 
 def register(ctx) -> None:

--- a/__init__.py
+++ b/__init__.py
@@ -15,6 +15,7 @@ This module only registers the plugin's command, hooks, and patches.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 from . import _config, social_learning, soul
@@ -34,15 +35,94 @@ from .turn_taking.service import _service_url
 _log = logging.getLogger(__name__)
 
 
-def _warn_misconfig() -> None:
-    """Fail loudly at startup on every misconfig that otherwise breaks silently.
+_TRUE = {"true", "1", "yes", "on"}
+_FALSE = {"false", "0", "no", "off"}
 
-    Each case produces broken behavior with no error near the cause (silent
-    idle, 401s, per-user group sessions, streamed replies the plugin can't
-    replace). Every problem is logged AND queued for the home chat, delivered on
-    the first inbound message (adapters aren't connected yet here) — except when
-    HUMALIKE_API_URL is unset, which leaves turn-taking off and no inbound path
-    to flush through, so that one stays log-only.
+
+def _resolve(env_key: str, cfg, section: str, cfg_key: str):
+    """A platform setting as the host resolves it: env var wins, else the
+    ``config.yaml`` platform-section key, else None. Checking both keeps us from
+    warning about something the operator set in yaml instead of env."""
+    v = os.environ.get(env_key)
+    if v not in (None, ""):
+        return v
+    sec = (cfg or {}).get(section) or {}
+    if isinstance(sec, dict) and sec.get(cfg_key) not in (None, ""):
+        return str(sec.get(cfg_key))
+    return None
+
+
+def _platform_config_problems(cfg) -> list:
+    """How each connected platform will behave given its auth/mention config —
+    surfaced when the bot will answer nowhere you'd expect. Only for platforms
+    actually in use (token/vars present), read from env AND config.yaml. Framed
+    as behaviour, not error: the fully-open setup is a choice, so this informs.
+    """
+    env = os.environ
+    out = []
+
+    # ── Telegram (in use if a bot token is set) ──
+    if env.get("TELEGRAM_BOT_TOKEN"):
+        raw = _resolve("TELEGRAM_GROUP_ALLOWED_CHATS", cfg, "telegram", "group_allowed_chats") or ""
+        chats = [c.strip() for c in raw.split(",") if c.strip()]
+        users = _resolve("TELEGRAM_GROUP_ALLOWED_USERS", cfg, "telegram", "group_allowed_users")
+        if not chats and not users:
+            out.append("Telegram: no group authorized (TELEGRAM_GROUP_ALLOWED_CHATS empty) — the bot "
+                       "IGNORES every group message. Add the group's chat id (negative) or '*'.")
+        for c in chats:
+            if c != "*" and not (c.startswith("-") and c[1:].isdigit()):
+                out.append(f"Telegram: TELEGRAM_GROUP_ALLOWED_CHATS entry '{c}' is not a group id "
+                           "(group ids are negative, e.g. -100…) — that entry authorizes nothing.")
+
+    # ── Slack (in use if a token is set) ──
+    if env.get("SLACK_BOT_TOKEN") or env.get("SLACK_APP_TOKEN"):
+        if env.get("SLACK_ALLOW_ALL_USERS", "").lower() not in _TRUE and not env.get("SLACK_ALLOWED_USERS", "").strip():
+            out.append("Slack: no user authorized — the bot IGNORES everyone. "
+                       "Set SLACK_ALLOW_ALL_USERS=true, or list SLACK_ALLOWED_USERS.")
+        mention = (_resolve("SLACK_REQUIRE_MENTION", cfg, "slack", "require_mention") or "").lower()
+        free = _resolve("SLACK_FREE_RESPONSE_CHANNELS", cfg, "slack", "free_response_channels")
+        if mention not in _FALSE and not free:
+            out.append("Slack: the bot only replies when @mentioned in channels. Set "
+                       "SLACK_REQUIRE_MENTION=false (or SLACK_FREE_RESPONSE_CHANNELS) to answer unmentioned messages.")
+
+    # ── WhatsApp (in use if any WHATSAPP_* var is set) ──
+    if any(k.startswith("WHATSAPP_") for k in env):
+        policy = (_resolve("WHATSAPP_GROUP_POLICY", cfg, "whatsapp", "group_policy") or "").lower()
+        if policy and policy not in {"open", "allowlist", "disabled", "pairing"}:
+            out.append(f"WhatsApp: WHATSAPP_GROUP_POLICY='{policy}' is not valid "
+                       "(open|allowlist|disabled|pairing) — likely a typo; groups may be blocked.")
+        elif policy in ("", "pairing"):
+            out.append("WhatsApp: group policy is 'pairing' (the default) — the bot will NOT answer in "
+                       "groups until each is paired. Set WHATSAPP_GROUP_POLICY=open to answer in all groups.")
+        wrm = (_resolve("WHATSAPP_REQUIRE_MENTION", cfg, "whatsapp", "require_mention") or "").lower()
+        if wrm and wrm not in _FALSE:
+            out.append("WhatsApp: WHATSAPP_REQUIRE_MENTION is on — the bot only replies when @mentioned.")
+
+    return out
+
+
+def _should_chat_warn() -> bool:
+    """Chat-warn about config exactly ONCE ever (until the marker file is
+    removed), then never again — a deliberate setup shouldn't be nagged for
+    eternity. Only called when there ARE problems, so the marker is written the
+    first time we'd actually warn. Logs still fire every boot regardless."""
+    marker = Path.home() / ".hermes" / ".turn_taking_config_warned"
+    if marker.exists():
+        return False
+    try:
+        marker.write_text("1")
+    except Exception:
+        pass  # best-effort; worst case the warning repeats, never lost
+    return True
+
+
+def _warn_misconfig() -> None:
+    """Warn about config that silently breaks turn-taking or makes the bot
+    answer nowhere. Two families: plugin-core (URL/key/streaming/group_sessions
+    — the plugin can't work) and per-platform auth/mention (it connects but
+    ignores messages). Logged in full on every start; pushed to the home chat
+    only the FIRST time (see _should_chat_warn), so a deliberate setup isn't
+    nagged forever. URL-unset stays log-only (no inbound path to flush).
     """
     problems = []
     if not _config.service_url():
@@ -68,10 +148,11 @@ def _warn_misconfig() -> None:
         if cfg.get("group_sessions_per_user", True):  # Hermes defaults this to true
             problems.append("group_sessions_per_user is not false — set "
                             "'group_sessions_per_user: false' (group chats need one shared thread).")
+    problems += _platform_config_problems(cfg)
     for p in problems:
         _log.warning("turn-taking: %s", p)
-    if problems:
-        notify.queue_startup("⚠️ turn-taking misconfigured:\n• " + "\n• ".join(problems))
+    if problems and _should_chat_warn():
+        notify.queue_startup("⚠️ turn-taking / platform config:\n• " + "\n• ".join(problems))
 
 
 def register(ctx) -> None:
@@ -106,6 +187,10 @@ def register(ctx) -> None:
         _log.info("turn-taking: registered social-learning pre_llm_call hook")
     except Exception as e:
         _log.warning("turn-taking: could not register social-learning hook: %s", e)
+    try:
+        social_learning.warm_recent_sessions()
+    except Exception as e:
+        _log.warning("turn-taking: social-learning warm-up skipped: %s", e)
     if not _service_url():
         return  # already warned loudly in _warn_misconfig()
     sent = _patch_send()

--- a/social_learning/__init__.py
+++ b/social_learning/__init__.py
@@ -238,6 +238,33 @@ def _refresh_card(session_id: str, conversation_history: Any) -> None:
         notify.alert_social(exc)
 
 
+# ── Detached refresh (shared by warm-up and the per-turn hook) ───────────────
+_REFRESHING: set = set()  # session ids with a refresh thread in flight
+
+
+def _spawn_refresh(session_id: str, history: Any) -> bool:
+    """Start a detached ``_refresh_card`` unless one is already in flight for
+    this session — at most one concurrent POST per session, so a slow or dead
+    service costs one 60s thread per session, not one per message (the no-card
+    branch fires every turn). Returns True if a thread was spawned.
+    ponytail: in-flight guard only; add time-based backoff if per-turn retries
+    against a dead service ever matter."""
+    with _LOCK:
+        if session_id in _REFRESHING:
+            return False
+        _REFRESHING.add(session_id)
+
+    def _run() -> None:
+        try:
+            _refresh_card(session_id, history)
+        finally:
+            with _LOCK:
+                _REFRESHING.discard(session_id)
+
+    threading.Thread(target=_run, daemon=True).start()
+    return True
+
+
 # ── Startup warm-up ──────────────────────────────────────────────────────────
 WARM_SESSIONS: int = 5
 
@@ -268,9 +295,7 @@ def warm_recent_sessions(limit: int = WARM_SESSIONS) -> None:
             if not session_id or already_cached:
                 continue
             history = db.get_messages_as_conversation(session_id)
-            threading.Thread(
-                target=_refresh_card, args=(session_id, history), daemon=True
-            ).start()
+            _spawn_refresh(session_id, history)
         logger.info("social-learning: warm-up fired for up to %d recent session(s)", len(sessions))
     except Exception as exc:
         logger.debug("social-learning: warm_recent_sessions failed: %s", exc)
@@ -296,15 +321,11 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[Dict[str, Any]]:
         )
 
         if (not has_card or n % REFRESH_EVERY == 0) and _get_service_url():
-            logger.info(
-                "social-learning: turn %d session %s — firing detached refresh (%s)",
-                n, session_id, "no card yet" if not has_card else "scheduled",
-            )
-            threading.Thread(
-                target=_refresh_card,
-                args=(session_id, list(conversation_history)),
-                daemon=True,
-            ).start()
+            if _spawn_refresh(session_id, list(conversation_history)):
+                logger.info(
+                    "social-learning: turn %d session %s — firing detached refresh (%s)",
+                    n, session_id, "no card yet" if not has_card else "scheduled",
+                )
 
         with _LOCK:
             card = _CACHE.get(session_id)

--- a/social_learning/__init__.py
+++ b/social_learning/__init__.py
@@ -238,6 +238,44 @@ def _refresh_card(session_id: str, conversation_history: Any) -> None:
         notify.alert_social(exc)
 
 
+# ── Startup warm-up ──────────────────────────────────────────────────────────
+WARM_SESSIONS: int = 5
+
+
+def warm_recent_sessions(limit: int = WARM_SESSIONS) -> None:
+    """Build voice cards for the ``limit`` most-recently-active sessions at
+    plugin registration, instead of waiting for each session's first
+    ``pre_llm_call``. Read-only DB access (no write-lock contention with the
+    live gateway); each session's history is fetched via the same
+    ``get_messages_as_conversation`` the gateway itself uses to restore
+    context, so the very first reply after a fresh install already has a
+    card if that session has prior history. Best-effort: never raises."""
+    try:
+        if not _get_service_url():
+            return
+        from hermes_constants import get_hermes_home  # noqa: PLC0415
+        from hermes_state import SessionDB  # noqa: PLC0415
+
+        db_path = get_hermes_home() / "state.db"
+        if not db_path.exists():
+            return
+        db = SessionDB(db_path=db_path, read_only=True)
+        sessions = db.list_sessions_rich(limit=limit, order_by_last_active=True)
+        for s in sessions:
+            session_id = s.get("id")
+            with _LOCK:
+                already_cached = session_id in _CACHE
+            if not session_id or already_cached:
+                continue
+            history = db.get_messages_as_conversation(session_id)
+            threading.Thread(
+                target=_refresh_card, args=(session_id, history), daemon=True
+            ).start()
+        logger.info("social-learning: warm-up fired for up to %d recent session(s)", len(sessions))
+    except Exception as exc:
+        logger.debug("social-learning: warm_recent_sessions failed: %s", exc)
+
+
 # ── Hook ──────────────────────────────────────────────────────────────────────
 def on_pre_llm_call(**kwargs: Any) -> Optional[Dict[str, Any]]:
     """pre_llm_call hook: inject the voice card and (every REFRESH_EVERY turns) refresh it."""
@@ -257,8 +295,11 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[Dict[str, Any]]:
             n, session_id, "cached" if has_card else "none", REFRESH_EVERY,
         )
 
-        if n % REFRESH_EVERY == 0 and _get_service_url():
-            logger.info("social-learning: turn %d session %s — firing detached refresh", n, session_id)
+        if (not has_card or n % REFRESH_EVERY == 0) and _get_service_url():
+            logger.info(
+                "social-learning: turn %d session %s — firing detached refresh (%s)",
+                n, session_id, "no card yet" if not has_card else "scheduled",
+            )
             threading.Thread(
                 target=_refresh_card,
                 args=(session_id, list(conversation_history)),

--- a/tests/test_misconfig.py
+++ b/tests/test_misconfig.py
@@ -1,0 +1,140 @@
+"""Checks for the platform-config warning logic in the plugin root module.
+
+The root __init__.py wires the whole plugin (patching, soul, connect…), so
+every sibling except _config is stubbed and only _resolve,
+_platform_config_problems and the chat-warn marker digest logic are exercised.
+Run directly:  python3 tests/test_misconfig.py
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+
+    pkg = types.ModuleType("_tt_test_pkg")
+    pkg.__path__ = [str(_ROOT)]
+    sys.modules["_tt_test_pkg"] = pkg
+
+    def _stub(name, **attrs):
+        m = types.ModuleType(f"_tt_test_pkg.{name}")
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        sys.modules[f"_tt_test_pkg.{name}"] = m
+        return m
+
+    def noop(*a, **k):
+        return None
+
+    _stub("connect", command=noop)
+    _stub("social_learning", on_pre_llm_call=noop, warm_recent_sessions=noop)
+    _stub("soul", command=noop, maybe_auto_enhance=noop)
+    tt = _stub("turn_taking")
+    tt.__path__ = []
+    tt.hooks = _stub("turn_taking.hooks", on_transform_llm_output=noop)
+    tt.patching = _stub("turn_taking.patching", **{n: (lambda: False) for n in (
+        "_patch__enqueue_text_event", "_patch_merge_pending_message_event",
+        "_patch__poll_messages", "_patch_send", "_patch_slack_handle_message",
+        "_patch_telegram_handle_message", "_patch_telegram_observe_group")})
+    tt.notify = _stub("turn_taking.notify", queue_startup=noop)
+    tt.service = _stub("turn_taking.service", _service_url=lambda: "")
+
+    cfg_spec = importlib.util.spec_from_file_location("_tt_test_pkg._config", _ROOT / "_config.py")
+    cfg = importlib.util.module_from_spec(cfg_spec)
+    sys.modules["_tt_test_pkg._config"] = cfg
+    cfg_spec.loader.exec_module(cfg)
+
+    spec = importlib.util.spec_from_file_location("_tt_test_pkg.plugin_root", _ROOT / "__init__.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_tt_test_pkg.plugin_root"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_MOD = _load()
+
+
+def test_resolve_yaml_first_lists_and_nesting():
+    """yaml wins over env (adapters read config.extra first), lists join to
+    CSV, and platforms.<name>/gateway.platforms.<name> nesting is found."""
+    cfg = {"telegram": {"group_allowed_chats": [-100123, -100456]}}
+    with patch.dict(os.environ, {"TELEGRAM_GROUP_ALLOWED_CHATS": "-1"}, clear=True):
+        got = _MOD._resolve("TELEGRAM_GROUP_ALLOWED_CHATS", cfg, "telegram", "group_allowed_chats")
+    assert got == "-100123,-100456", got
+
+    nested = {"platforms": {"slack": {"require_mention": False}}}
+    with patch.dict(os.environ, {}, clear=True):
+        assert _MOD._resolve("SLACK_REQUIRE_MENTION", nested, "slack", "require_mention") == "False"
+        assert _MOD._resolve("SLACK_REQUIRE_MENTION", None, "slack", "require_mention") is None
+        deep = {"gateway": {"platforms": {"whatsapp": {"group_policy": "open"}}}}
+        assert _MOD._resolve("WHATSAPP_GROUP_POLICY", deep, "whatsapp", "group_policy") == "open"
+
+
+def test_platform_problems_telegram():
+    # Valid yaml list -> no warnings at all.
+    with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "t"}, clear=True):
+        assert _MOD._platform_config_problems({"telegram": {"group_allowed_chats": [-100123]}}) == []
+    # User-level auth alone does NOT enable group observation -> still warns.
+    with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_ALLOWED_USERS": "42",
+                                 "TELEGRAM_GROUP_ALLOWED_USERS": "42"}, clear=True):
+        probs = _MOD._platform_config_problems({})
+        assert len(probs) == 1 and "cannot observe" in probs[0], probs
+    # '*' is matched literally by the host -> flagged as authorizing nothing.
+    with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_GROUP_ALLOWED_CHATS": "*"}, clear=True):
+        assert any("authorizes nothing" in p for p in _MOD._platform_config_problems({}))
+
+
+def test_platform_problems_slack():
+    # 'on' is not host-truthy: flagged as unrecognized AND nobody is authorized.
+    with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "t", "SLACK_ALLOW_ALL_USERS": "on",
+                                 "SLACK_REQUIRE_MENTION": "false"}, clear=True):
+        probs = _MOD._platform_config_problems({})
+        assert any("not a value Hermes accepts" in p for p in probs), probs
+        assert any("no user authorized" in p for p in probs), probs
+    # GATEWAY_ALLOWED_USERS counts as authorization (host honors it).
+    with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "t", "GATEWAY_ALLOWED_USERS": "U1",
+                                 "SLACK_REQUIRE_MENTION": "false"}, clear=True):
+        assert _MOD._platform_config_problems({}) == []
+
+
+def test_platform_problems_whatsapp():
+    # Explicitly disabled (or cloud-only vars) -> platform not in use, no warnings.
+    with patch.dict(os.environ, {"WHATSAPP_ENABLED": "false", "WHATSAPP_CLOUD_ACCESS_TOKEN": "x"}, clear=True):
+        assert _MOD._platform_config_problems({}) == []
+    # Enabled with default policy -> pairing warning.
+    with patch.dict(os.environ, {"WHATSAPP_ENABLED": "true"}, clear=True):
+        assert any("pairing" in p for p in _MOD._platform_config_problems({}))
+
+
+def test_chat_warn_digest_marker():
+    """Marker written only via _mark_chat_warned (delivery), keyed by problem
+    digest: same set silent, changed set warns again; dir auto-created."""
+    import tempfile
+
+    home = Path(tempfile.mkdtemp()) / "hermes-home"  # does not exist yet
+    fake_hc = types.ModuleType("hermes_constants")
+    fake_hc.get_hermes_home = lambda: home
+    sys.modules["hermes_constants"] = fake_hc
+    try:
+        assert _MOD._should_chat_warn("d1") is True
+        _MOD._mark_chat_warned("d1")
+        assert (home / ".turn_taking_config_warned").exists()
+        assert _MOD._should_chat_warn("d1") is False
+        assert _MOD._should_chat_warn("d2") is True
+    finally:
+        sys.modules.pop("hermes_constants", None)
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok  {name}")
+    print("all tests passed")

--- a/tests/test_social_learning.py
+++ b/tests/test_social_learning.py
@@ -119,7 +119,7 @@ def test_warm_recent_sessions_skips_already_cached():
     sys.modules["hermes_state"] = fake_hs
 
     class SyncThread:
-        def __init__(self, target, args, daemon):
+        def __init__(self, target=None, args=(), daemon=None):
             self._target, self._args = target, args
 
         def start(self):
@@ -143,6 +143,36 @@ def test_warm_recent_sessions_skips_already_cached():
         sys.modules.pop("hermes_state", None)
 
     assert calls == ["warm-1"], calls
+
+
+def test_spawn_refresh_dedups_in_flight():
+    """While a refresh runs for a session, further spawns for it are skipped."""
+    import threading
+
+    calls = []
+    orig_refresh, orig_thread = sl._refresh_card, threading.Thread
+    sl._refresh_card = lambda session_id, history: calls.append(session_id)
+
+    class SyncThread:
+        def __init__(self, target=None, args=(), daemon=None):
+            self._target, self._args = target, args
+
+        def start(self):
+            self._target(*self._args)
+
+    threading.Thread = SyncThread
+    try:
+        sl._REFRESHING.add("dup-1")                      # simulate one in flight
+        assert sl._spawn_refresh("dup-1", []) is False
+        assert calls == []
+        sl._REFRESHING.discard("dup-1")
+        assert sl._spawn_refresh("dup-1", []) is True
+        assert calls == ["dup-1"]
+        assert "dup-1" not in sl._REFRESHING             # cleaned up after the run
+    finally:
+        threading.Thread = orig_thread
+        sl._refresh_card = orig_refresh
+        sl._REFRESHING.discard("dup-1")
 
 
 if __name__ == "__main__":

--- a/tests/test_social_learning.py
+++ b/tests/test_social_learning.py
@@ -91,6 +91,60 @@ def test_cache_survives_reload_from_disk():
         sl._CACHE.pop("restart-test", None)
 
 
+def test_warm_recent_sessions_skips_already_cached():
+    """Fires _refresh_card for uncached recent sessions only, using each
+    session's DB-restored history (not the live pre_llm_call kwarg)."""
+    import tempfile
+    import threading
+
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "state.db").write_text("x")
+
+    fake_hc = types.ModuleType("hermes_constants")
+    fake_hc.get_hermes_home = lambda: tmp
+    sys.modules["hermes_constants"] = fake_hc
+
+    class FakeDB:
+        def __init__(self, db_path, read_only):
+            pass
+
+        def list_sessions_rich(self, limit, order_by_last_active):
+            return [{"id": "warm-1"}, {"id": "warm-2"}]
+
+        def get_messages_as_conversation(self, session_id):
+            return [{"role": "user", "content": "hello there"}]
+
+    fake_hs = types.ModuleType("hermes_state")
+    fake_hs.SessionDB = FakeDB
+    sys.modules["hermes_state"] = fake_hs
+
+    class SyncThread:
+        def __init__(self, target, args, daemon):
+            self._target, self._args = target, args
+
+        def start(self):
+            self._target(*self._args)
+
+    sl._CACHE.pop("warm-1", None)
+    sl._CACHE["warm-2"] = "already cached — should be skipped"
+    calls = []
+    orig_get_url, orig_refresh, orig_thread = sl._get_service_url, sl._refresh_card, threading.Thread
+    sl._get_service_url = lambda: "http://example.test"
+    sl._refresh_card = lambda session_id, history: calls.append(session_id)
+    threading.Thread = SyncThread
+    try:
+        sl.warm_recent_sessions()
+    finally:
+        threading.Thread = orig_thread
+        sl._get_service_url = orig_get_url
+        sl._refresh_card = orig_refresh
+        sl._CACHE.pop("warm-2", None)
+        sys.modules.pop("hermes_constants", None)
+        sys.modules.pop("hermes_state", None)
+
+    assert calls == ["warm-1"], calls
+
+
 if __name__ == "__main__":
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):

--- a/turn_taking/notify.py
+++ b/turn_taking/notify.py
@@ -28,7 +28,7 @@ _COOLDOWN_S = 30 * 60
 _LOCK = threading.Lock()             # alert() is now called from >1 thread
 _last_by_kind: dict[str, float] = {}  # error kind → monotonic ts of last alert
 _active_kinds: set[str] = set()       # kinds currently in the "failing" state
-_pending: list[str] = []              # startup misconfig msgs, flushed on 1st inbound
+_pending: list = []                   # (text, on_delivered) startup msgs, flushed on 1st inbound
 
 WS_LOST = ("⚠️ Humalike realtime connection lost — the bot may go SILENT in "
            "affected chats until the gateway restarts.")
@@ -124,10 +124,12 @@ def recovered() -> None:
         pass
 
 
-def queue_startup(text: str) -> None:
+def queue_startup(text: str, on_delivered=None) -> None:
     """Queue a startup misconfig alert; delivered on the first inbound message
-    (adapters aren't connected yet at register() time)."""
-    _pending.append(text)
+    (adapters aren't connected yet at register() time). ``on_delivered`` fires
+    only after the text actually reached at least one home channel — callers
+    use it to record "warned" without losing warnings that never got through."""
+    _pending.append((text, on_delivered))
 
 
 def flush_pending() -> None:
@@ -137,8 +139,16 @@ def flush_pending() -> None:
         return
     with _LOCK:
         msgs, _pending[:] = list(_pending), []
-    for m in msgs:
-        _schedule(lambda m=m: _send(m))
+    for m, cb in msgs:
+        _schedule(lambda m=m, cb=cb: _deliver_startup(m, cb))
+
+
+async def _deliver_startup(text: str, cb) -> None:
+    if await _send(text) and cb is not None:
+        try:
+            cb()
+        except Exception:
+            _log.warning("notify: on_delivered callback failed", exc_info=True)
 
 
 # ── Delivery ──────────────────────────────────────────────────────────────────
@@ -155,10 +165,10 @@ def _gateway() -> Any:
     return None
 
 
-async def _send(text: str) -> None:
+async def _send(text: str) -> bool:
     gw = _gateway()
     if gw is None:
-        return  # no adapter/gateway seen yet — nothing to send through (caller logged)
+        return False  # no adapter/gateway seen yet — nothing to send through (caller logged)
     # Every configured home channel — one platform failing must not skip the rest.
     sent_any = False
     for platform, adp in list(getattr(gw, "adapters", {}).items()):
@@ -178,3 +188,4 @@ async def _send(text: str) -> None:
             _log.warning("notify: alert to %s home failed: %s", platform, e)
     if not sent_any:
         _log.info("notify: no home channel set — run /sethome to get alerts in chat")
+    return sent_any


### PR DESCRIPTION
## Co się zmienia

### 1. Walidacja konfiguracji platform w `_warn_misconfig`
- Nowe `_platform_config_problems()`: dla platform faktycznie w użyciu (token/vars obecne) sprawdza, czy bot będzie gdziekolwiek odpowiadał:
  - **Telegram** — pusta `TELEGRAM_GROUP_ALLOWED_CHATS` (bot ignoruje grupy), wpisy niebędące id grupy.
  - **Slack** — brak autoryzowanych userów, domyślne odpowiadanie tylko na @wzmianki.
  - **WhatsApp** — literówka w `WHATSAPP_GROUP_POLICY`, domyślny `pairing`, włączone `require_mention`.
- `_resolve()` czyta ustawienia jak host: env var, potem `config.yaml`.
- Ostrzeżenie na czacie domowym leci **tylko raz** (marker `~/.hermes/.turn_taking_config_warned`); logi nadal przy każdym starcie.

### 2. Warm-up voice cards przy starcie
- `warm_recent_sessions(limit=5)`: przy rejestracji pluginu buduje karty dla 5 ostatnio aktywnych sesji z historii odtworzonej z `state.db` (read-only), więc pierwsza odpowiedź po restarcie ma już kartę. Best-effort, nigdy nie rzuca.
- `on_pre_llm_call`: refresh odpala się też natychmiast, gdy sesja nie ma jeszcze karty (nie tylko co `REFRESH_EVERY` tur).

### 3. Test
- `test_warm_recent_sessions_skips_already_cached` — warm-up odświeża tylko sesje bez karty w cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added best-effort warmup of recent session history to improve voice-card readiness.
  * Enhanced refresh triggering to run immediately when a session has no cached card.
  * Improved startup notification delivery by supporting an optional “delivered” callback after successful home-channel sending.

* **Bug Fixes**
  * Added platform-specific misconfiguration detection for Telegram, Slack, and WhatsApp with clearer startup warnings.
  * Reduced repeated chat-warning noise using a digest-based “show once per distinct issue set” marker.
  * Deduplicated concurrent refresh attempts per session to avoid redundant refresh work.

* **Tests**
  * Added unit tests covering warmup skipping, refresh in-flight deduping, and misconfiguration/digest behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->