### PR TITLE
/connect: link a Humalike account from chat (device authorization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,33 +41,24 @@ git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/h
 hermes plugins enable humalike
 ```
 
-`~/.hermes/.env` — one URL + one key for all Humalike calls
-(`Authorization: Bearer`):
+No env setup needed: the API URL defaults to `https://api.humalike.com`, and
+the API key comes from a device login the plugin runs for you:
 
-```bash
-HUMALIKE_API_URL=https://api.humalike.com
-HUMALIKE_API_KEY=your-api-key   # or skip and use /connect (below)
-```
-
-No key yet? Two ways to link your Humalike account — no copy-pasting keys:
-
-- **At install time, in the terminal** (stdlib-only, no Hermes venv needed):
-
-  ```bash
-  python3 ~/.hermes/plugins/humalike/login.py
-  ```
-
-  Prints the approval link, opens a browser tab when the machine has one
-  (on SSH/headless boxes open the printed link on your phone), and writes
-  the key to `~/.hermes/.env`. The first gateway start also pops this login
-  automatically if the key is still missing.
-
+- **Automatic**: the first start without a key prints a login link on the
+  console (and opens a browser tab when the machine has one). Approve it on
+  any device — your phone works — and the key is saved to `~/.hermes/.env`.
+- **At install time**: `python3 ~/.hermes/plugins/humalike/login.py` — the
+  same flow in the terminal (stdlib-only, no Hermes venv needed).
 - **From chat**: send the bot `/connect`. Same flow, and the key goes live
   without a restart.
 
-Both authenticate their setup calls with the plugin's public client
-identifier — until a default ships baked in, also set
-`HUMALIKE_CLI_GATEWAY_KEY` in `~/.hermes/.env` (value in the Humalike docs).
+Already have a key, or need a different environment? `~/.hermes/.env`
+overrides (`Authorization: Bearer`):
+
+```bash
+HUMALIKE_API_KEY=your-api-key   # skips the login
+HUMALIKE_API_URL=…              # non-default environment; set EMPTY to disable turn-taking
+```
 
 `~/.hermes/config.yaml` — all required:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ your bot feel like a person in the chat, powered by the
 
 ## Install
 
+First update Hermes to the latest version - the plugin patches into Hermes
+internals, so an out-of-date Hermes can leave turn-taking silently unhooked:
+
+```bash
+hermes update
+```
+
+Then clone and enable:
+
 ```bash
 git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/humalike
 

--- a/README.md
+++ b/README.md
@@ -57,15 +57,13 @@ actually starts. Use whatever command runs your bot - `hermes`, or your gateway
 start command.)
 
 No env setup needed: the API URL defaults to `https://api.humalike.com`, and
-the API key comes from a device login the plugin runs for you:
+the key is handled for you. When you start Hermes, the plugin applies its
+configuration and prints a login URL on the console (and opens a browser tab
+when the machine has one). Open it on any device - your phone works - approve,
+and the key is saved to `~/.hermes/.env`.
 
-- **Automatic**: the first start without a key prints a login link on the
-  console (and opens a browser tab when the machine has one). Approve it on
-  any device - your phone works - and the key is saved to `~/.hermes/.env`.
-- **At install time**: `python3 ~/.hermes/plugins/humalike/login.py` - the
-  same flow in the terminal (stdlib-only, no Hermes venv needed).
-- **From chat**: send the bot `/connect`. Same flow, and the key goes live
-  without a restart.
+You can also send the bot `/connect` at any time to link an account from chat;
+the key goes live without a restart.
 
 ### Configured for you on the first start
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ A [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin that makes
 your bot feel like a person in the chat, powered by the
 [Humalike](https://docs.humalike.com) APIs:
 
-- **[Turn-taking](https://docs.humalike.com/api-reference/turn-taking/overview)** —
+- **[Turn-taking](https://docs.humalike.com/api-reference/turn-taking/overview)** -
   decides when to jump in vs stay silent, and naturalizes replies so they read
   like a person wrote them, not one wall of bot text.
-- **[Persona](https://docs.humalike.com/api-reference/personas)** —
+- **[Persona](https://docs.humalike.com/api-reference/personas)** -
   `/soul enhance` turns a one-line description into a fleshed-out character
   with a real voice.
-- **[Theory of mind](https://docs.humalike.com/api-reference/foresee)** —
+- **[Theory of mind](https://docs.humalike.com/api-reference/foresee)** -
   considers how a message will land for the reader and adjusts before sending.
-- **[Social learning](https://docs.humalike.com/api-reference/extract)** —
+- **[Social learning](https://docs.humalike.com/api-reference/extract)** -
   picks up the group's slang, formatting, and jokes, and starts sounding like
   a member rather than a visitor.
 
@@ -32,7 +32,7 @@ your bot feel like a person in the chat, powered by the
 ```bash
 git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/humalike
 
-# run `hermes` from your Hermes install — activate its virtualenv first
+# run `hermes` from your Hermes install - activate its virtualenv first
 # (or call the hermes CLI by its full path)
 hermes plugins enable humalike
 ```
@@ -42,8 +42,8 @@ the API key comes from a device login the plugin runs for you:
 
 - **Automatic**: the first start without a key prints a login link on the
   console (and opens a browser tab when the machine has one). Approve it on
-  any device — your phone works — and the key is saved to `~/.hermes/.env`.
-- **At install time**: `python3 ~/.hermes/plugins/humalike/login.py` — the
+  any device - your phone works - and the key is saved to `~/.hermes/.env`.
+- **At install time**: `python3 ~/.hermes/plugins/humalike/login.py` - the
   same flow in the terminal (stdlib-only, no Hermes venv needed).
 - **From chat**: send the bot `/connect`. Same flow, and the key goes live
   without a restart.
@@ -51,7 +51,7 @@ the API key comes from a device login the plugin runs for you:
 ### Configured for you on the first start
 
 Everything turn-taking needs is applied automatically the first time the plugin
-runs — it writes these settings itself and prints exactly what it changed. You
+runs - it writes these settings itself and prints exactly what it changed. You
 don't set any of them by hand; they're listed here so you know what and why:
 
 | Setting (file) | Set to | Why |
@@ -62,22 +62,22 @@ don't set any of them by hand; they're listed here so you know what and why:
 | `slack.reply_in_thread` (config.yaml, only if Slack is connected) | `false` | one shared conversation per channel; the default starts a fresh thread + session for **every** message, so the bot would answer each one separately |
 | `WHATSAPP_*` / `SLACK_*` respond-to-everyone (`.env`, only for a connected platform) | open | reply to everyone in DMs and groups without needing an @mention |
 
-**Restart the gateway once after this first boot** so the new values load — the
+**Restart the gateway once after this first boot** so the new values load - the
 plugin's report ends with that reminder.
 
-### Action required — the few things it can't do for you
+### Action required - the few things it can't do for you
 
-- **Persona file location** — the plugin reads your persona from
+- **Persona file location** - the plugin reads your persona from
   `~/.hermes/SOUL.md`. If yours lives somewhere else (e.g. a Docker mount),
   point it there in `~/.hermes/config.yaml`:
   ```yaml
   turn_taking:
     soul_path: "/path/to/SOUL.md"
   ```
-- **Telegram groups** — two steps that genuinely can't be automated: disable
+- **Telegram groups** - two steps that genuinely can't be automated: disable
   privacy mode in @BotFather, and add the group's chat id to
   `TELEGRAM_GROUP_ALLOWED_CHATS`. The plugin prints both when Telegram is in use.
-- **A personal WhatsApp number** — the respond-to-everyone setting means the bot
+- **A personal WhatsApp number** - the respond-to-everyone setting means the bot
   replies to *everyone* who messages that number, in DMs and all groups. If it's
   your personal number, tighten it (the plugin warns about this at setup):
   `WHATSAPP_ALLOW_ALL_USERS=false` and/or `WHATSAPP_GROUP_POLICY=allowlist`.
@@ -91,11 +91,11 @@ HUMALIKE_API_KEY=your-api-key   # skips the device login
 HUMALIKE_API_URL=…              # non-default environment; set EMPTY to disable turn-taking
 ```
 
-Optional persona knob in `~/.hermes/config.yaml` under `turn_taking:` —
+Optional persona knob in `~/.hermes/config.yaml` under `turn_taking:` -
 `soul_auto_enhance` (`true` by default: the one-shot persona pass on first
 startup; set `false` to skip it).
 
-That's it — restart the gateway and message the bot. It now reads the room and
+That's it - restart the gateway and message the bot. It now reads the room and
 replies when it has something to say.
 
 ## Platforms
@@ -110,7 +110,7 @@ replies when it has something to say.
 
 Send the bot `/soul enhance` to deepen its persona: reads `SOUL.md`, enhances
 it via the [Personas API](https://docs.humalike.com/api-reference/personas),
-backs up the old file to `SOUL.md.bak`, writes the result — effective on the
+backs up the old file to `SOUL.md.bak`, writes the result - effective on the
 next message. Needs a seed description first; a bare template is skipped. Runs
 once automatically on first startup (disable: `soul_auto_enhance: false`).
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,10 @@ hermes
 actually starts. Use whatever command runs your bot - `hermes`, or your gateway
 start command.)
 
-No env setup needed: the API URL defaults to `https://api.humalike.com`, and
-the key is handled for you. When you start Hermes, the plugin applies its
-configuration and prints a login URL on the console (and opens a browser tab
-when the machine has one). Open it on any device - your phone works - approve,
-and the key is saved to `~/.hermes/.env`.
+On first start the plugin applies every required config
+change itself and prints what it changed, where, and why. For authentication it
+prints a login URL (and opens a browser tab when the machine has one) - approve
+on any device and the key is saved to `~/.hermes/.env`.
 
 You can also send the bot `/connect` at any time to link an account from chat;
 the key goes live without a restart.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ plugin's report ends with that reminder.
 `~/.hermes/.env` (`Authorization: Bearer`):
 
 ```bash
-HUMALIKE_API_KEY=your-api-key   # skips the device login
+HUMALIKE_API_KEY=your-api-key   # skips the login prompt
 HUMALIKE_API_URL=…              # non-default environment; set EMPTY to disable turn-taking
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,14 @@ hermes plugins enable turn-taking
 
 ```bash
 HUMALIKE_API_URL=https://api.humalike.com
-HUMALIKE_API_KEY=your-api-key
+HUMALIKE_API_KEY=your-api-key   # or skip and use /connect (below)
 ```
+
+No key yet? Leave `HUMALIKE_API_KEY` unset, start the gateway, and send the
+bot `/connect` from any chat. It replies with a login link; approve it in a
+browser on any device (your phone works — nothing needs to open on the gateway
+box, so SSH/VM/Docker installs are fine) and the key is saved to
+`~/.hermes/.env` and goes live without a restart.
 
 `~/.hermes/config.yaml` — all required:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ browser on any device (your phone works — nothing needs to open on the gateway
 box, so SSH/VM/Docker installs are fine) and the key is saved to
 `~/.hermes/.env` and goes live without a restart.
 
+`/connect` authenticates its setup calls with the plugin's public client
+identifier — until a default ships baked in, also set
+`HUMALIKE_CLI_GATEWAY_KEY` in `~/.hermes/.env` (value in the Humalike docs).
+
 `~/.hermes/config.yaml` — all required:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ your bot feel like a person in the chat, powered by the
 > and it can do all of the below for you.
 
 ```bash
-git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/turn-taking
+git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/humalike
 
 # run `hermes` from your Hermes install — activate its virtualenv first
 # (or call the hermes CLI by its full path)
-hermes plugins enable turn-taking
+hermes plugins enable humalike
 ```
 
 `~/.hermes/.env` — one URL + one key for all Humalike calls
@@ -54,7 +54,7 @@ No key yet? Two ways to link your Humalike account — no copy-pasting keys:
 - **At install time, in the terminal** (stdlib-only, no Hermes venv needed):
 
   ```bash
-  python3 ~/.hermes/plugins/turn-taking/login.py
+  python3 ~/.hermes/plugins/humalike/login.py
   ```
 
   Prints the approval link, opens a browser tab when the machine has one

--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ your bot feel like a person in the chat, powered by the
 
 ## Install
 
-> Using an agent harness (Claude Code, etc.)? Point it at
-> [`skills/install-turn-taking/SKILL.md`](skills/install-turn-taking/SKILL.md)
-> and it can do all of the below for you.
-
 ```bash
 git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/humalike
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/h
 hermes plugins enable humalike
 ```
 
+Then start Hermes so the plugin loads and runs its first-start setup:
+
+```bash
+hermes
+```
+
+(`hermes plugins enable` only records the plugin; nothing happens until Hermes
+actually starts. Use whatever command runs your bot - `hermes`, or your gateway
+start command.)
+
 No env setup needed: the API URL defaults to `https://api.humalike.com`, and
 the API key comes from a device login the plugin runs for you:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ the API key comes from a device login the plugin runs for you:
 - **From chat**: send the bot `/connect`. Same flow, and the key goes live
   without a restart.
 
+The first start also configures hermes itself: the required chat settings
+(streaming off, one shared thread per group, tool chatter hidden) and — when
+WhatsApp or Slack is connected — the respond-to-everyone group settings.
+Telegram's two manual steps (BotFather privacy mode, group ids) are prompted
+on the console. Restart once after that first boot to apply.
+
 Already have a key, or need a different environment? `~/.hermes/.env`
 overrides (`Authorization: Bearer`):
 

--- a/README.md
+++ b/README.md
@@ -52,36 +52,55 @@ the API key comes from a device login the plugin runs for you:
 - **From chat**: send the bot `/connect`. Same flow, and the key goes live
   without a restart.
 
-The first start also configures hermes itself: the required chat settings
-(streaming off, one shared thread per group, tool chatter hidden) and — when
-WhatsApp or Slack is connected — the respond-to-everyone group settings.
-Telegram's two manual steps (BotFather privacy mode, group ids) are prompted
-on the console. Restart once after that first boot to apply.
+### Configured for you on the first start
 
-Already have a key, or need a different environment? `~/.hermes/.env`
-overrides (`Authorization: Bearer`):
+Everything turn-taking needs is applied automatically the first time the plugin
+runs — it writes these settings itself and prints exactly what it changed. You
+don't set any of them by hand; they're listed here so you know what and why:
+
+| Setting (file) | Set to | Why |
+|---|---|---|
+| `streaming` (config.yaml) | `false` | the plugin rewrites the final reply into human-style messages, so Hermes must not also stream its own raw draft over the top |
+| `group_sessions_per_user` (config.yaml) | `false` | everyone in a group shares one conversation, so the bot follows the whole room instead of a separate thread per person |
+| `display.tool_progress` (config.yaml) | `off` | hides "Browsing…/Clicking…" tool chatter so replies read as human |
+| `slack.reply_in_thread` (config.yaml, only if Slack is connected) | `false` | one shared conversation per channel; the default starts a fresh thread + session for **every** message, so the bot would answer each one separately |
+| `WHATSAPP_*` / `SLACK_*` respond-to-everyone (`.env`, only for a connected platform) | open | reply to everyone in DMs and groups without needing an @mention |
+
+**Restart the gateway once after this first boot** so the new values load — the
+plugin's report ends with that reminder.
+
+### Action required — the few things it can't do for you
+
+- **Persona file location** — the plugin reads your persona from
+  `~/.hermes/SOUL.md`. If yours lives somewhere else (e.g. a Docker mount),
+  point it there in `~/.hermes/config.yaml`:
+  ```yaml
+  turn_taking:
+    soul_path: "/path/to/SOUL.md"
+  ```
+- **Telegram groups** — two steps that genuinely can't be automated: disable
+  privacy mode in @BotFather, and add the group's chat id to
+  `TELEGRAM_GROUP_ALLOWED_CHATS`. The plugin prints both when Telegram is in use.
+- **A personal WhatsApp number** — the respond-to-everyone setting means the bot
+  replies to *everyone* who messages that number, in DMs and all groups. If it's
+  your personal number, tighten it (the plugin warns about this at setup):
+  `WHATSAPP_ALLOW_ALL_USERS=false` and/or `WHATSAPP_GROUP_POLICY=allowlist`.
+
+### Overrides
+
+`~/.hermes/.env` (`Authorization: Bearer`):
 
 ```bash
-HUMALIKE_API_KEY=your-api-key   # skips the login
+HUMALIKE_API_KEY=your-api-key   # skips the device login
 HUMALIKE_API_URL=…              # non-default environment; set EMPTY to disable turn-taking
 ```
 
-`~/.hermes/config.yaml` — all required:
+Optional persona knob in `~/.hermes/config.yaml` under `turn_taking:` —
+`soul_auto_enhance` (`true` by default: the one-shot persona pass on first
+startup; set `false` to skip it).
 
-```yaml
-streaming: false                # the plugin replaces the final reply text
-group_sessions_per_user: false  # one thread per group chat
-display:
-  tool_progress: "off"          # hide tool-call chatter (Browsing/Clicking/…) so replies read as human
-
-turn_taking:
-  soul_path: "~/.hermes/SOUL.md"  # where your SOUL.md actually lives — adjust if elsewhere (e.g. a Docker mount)
-  soul_grounding: "off"           # off | web | research — real-world research when enhancing the persona
-  soul_auto_enhance: true         # one-shot persona enhance on first startup
-```
-
-Restart the gateway and message the bot — it now reads the room and replies
-when it has something to say. Done.
+That's it — restart the gateway and message the bot. It now reads the room and
+replies when it has something to say.
 
 ## Platforms
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,23 @@ HUMALIKE_API_URL=https://api.humalike.com
 HUMALIKE_API_KEY=your-api-key   # or skip and use /connect (below)
 ```
 
-No key yet? Leave `HUMALIKE_API_KEY` unset, start the gateway, and send the
-bot `/connect` from any chat. It replies with a login link; approve it in a
-browser on any device (your phone works — nothing needs to open on the gateway
-box, so SSH/VM/Docker installs are fine) and the key is saved to
-`~/.hermes/.env` and goes live without a restart.
+No key yet? Two ways to link your Humalike account — no copy-pasting keys:
 
-`/connect` authenticates its setup calls with the plugin's public client
+- **At install time, in the terminal** (stdlib-only, no Hermes venv needed):
+
+  ```bash
+  python3 ~/.hermes/plugins/turn-taking/login.py
+  ```
+
+  Prints the approval link, opens a browser tab when the machine has one
+  (on SSH/headless boxes open the printed link on your phone), and writes
+  the key to `~/.hermes/.env`. The first gateway start also pops this login
+  automatically if the key is still missing.
+
+- **From chat**: send the bot `/connect`. Same flow, and the key goes live
+  without a restart.
+
+Both authenticate their setup calls with the plugin's public client
 identifier — until a default ships baked in, also set
 `HUMALIKE_CLI_GATEWAY_KEY` in `~/.hermes/.env` (value in the Humalike docs).
 

--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@ import logging
 import os
 from pathlib import Path
 
-from . import _config, social_learning, soul
+from . import _config, connect, social_learning, soul
 from .turn_taking.hooks import on_transform_llm_output
 from .turn_taking.patching import (
     _patch__enqueue_text_event,
@@ -130,7 +130,8 @@ def _warn_misconfig() -> None:
                         "(/soul still works). Add it to ~/.hermes/.env.")
     elif not _config.api_key():
         problems.append("HUMALIKE_API_KEY is not set — every Humalike call will "
-                        "fail with 401. Add it to ~/.hermes/.env.")
+                        "fail with 401. Send the bot /connect to link your "
+                        "Humalike account, or add the key to ~/.hermes/.env.")
     try:
         import yaml
 
@@ -173,6 +174,14 @@ def register(ctx) -> None:
         _log.info("turn-taking: registered /soul command")
     except Exception as e:
         _log.warning("turn-taking: could not register /soul command: %s", e)
+    try:
+        ctx.register_command(
+            "connect", connect.command,
+            description="Link this agent to your Humalike account (device login)",
+        )
+        _log.info("turn-taking: registered /connect command")
+    except Exception as e:
+        _log.warning("turn-taking: could not register /connect command: %s", e)
     try:
         soul.maybe_auto_enhance()  # one-shot on first startup (marker-guarded)
     except Exception as e:

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ import logging
 import os
 from pathlib import Path
 
-from . import _config, connect, login, social_learning, soul
+from . import _config, autoconfig, connect, login, social_learning, soul
 from .turn_taking.hooks import on_transform_llm_output
 from .turn_taking.patching import (
     _patch__enqueue_text_event,
@@ -221,6 +221,14 @@ def register(ctx) -> None:
     otherwise) — the ``/soul`` persona command is registered regardless (it
     uses the separate Personas API, not the turn-taking service).
     """
+    try:
+        # First boot: apply the deterministic parts of the install/configure
+        # skills (required config.yaml settings; respond-to-everyone env for
+        # WhatsApp/Slack when in use; Telegram's manual steps prompted). Runs
+        # BEFORE _warn_misconfig so the warnings reflect the fixed state.
+        autoconfig.maybe_autoconfigure()
+    except Exception as e:
+        _log.warning("turn-taking: autoconfig skipped: %s", e)
     _warn_misconfig()
     try:
         # First keyless boot: pop the device-auth login once (browser tab on a

--- a/__init__.py
+++ b/__init__.py
@@ -113,6 +113,12 @@ def _platform_config_problems(cfg) -> list:
         if mention not in _FALSE and not free:
             out.append("Slack: the bot only replies when @mentioned in channels. Set "
                        "SLACK_REQUIRE_MENTION=false (or SLACK_FREE_RESPONSE_CHANNELS) to answer unmentioned messages.")
+        rit = next((sec.get("reply_in_thread") for sec in _sections(cfg, "slack")
+                    if "reply_in_thread" in sec), None)
+        if rit is None or str(rit).strip().lower() not in _FALSE:
+            out.append("Slack: reply_in_thread is not false — every top-level channel message "
+                       "becomes its own thread AND its own session, so turn-taking answers each "
+                       "message separately. Set 'slack:\n  reply_in_thread: false' in ~/.hermes/config.yaml.")
 
     # ── WhatsApp (in use only when the host would enable it: WHATSAPP_ENABLED
     # truthy — WHATSAPP_ENABLED=false or WHATSAPP_CLOUD_* alone don't count) ──

--- a/__init__.py
+++ b/__init__.py
@@ -14,6 +14,7 @@ This module only registers the plugin's command, hooks, and patches.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 from pathlib import Path
@@ -35,21 +36,36 @@ from .turn_taking.service import _service_url
 _log = logging.getLogger(__name__)
 
 
-_TRUE = {"true", "1", "yes", "on"}
+# The host's truthy set for allow-all/enabled flags is exactly this — no "on"
+# (slack/whatsapp adapters use `in {"true", "1", "yes"}`). _FALSE matches the
+# host's require_mention parse (`not in {"false", "0", "no", "off"}`).
+_HOST_TRUE = {"true", "1", "yes"}
 _FALSE = {"false", "0", "no", "off"}
 
 
+def _sections(cfg, name):
+    """Every yaml spot the host reads a platform section from: top-level
+    ``<name>:``, ``platforms.<name>:`` and ``gateway.platforms.<name>:``."""
+    c = cfg if isinstance(cfg, dict) else {}
+    for holder in (c, c.get("platforms"), (c.get("gateway") or {}).get("platforms")):
+        sec = holder.get(name) if isinstance(holder, dict) else None
+        if isinstance(sec, dict):
+            yield sec
+
+
 def _resolve(env_key: str, cfg, section: str, cfg_key: str):
-    """A platform setting as the host resolves it: env var wins, else the
-    ``config.yaml`` platform-section key, else None. Checking both keeps us from
-    warning about something the operator set in yaml instead of env."""
+    """A platform setting as the host resolves it: adapters read their yaml
+    section (``config.extra``) before env, so yaml wins here too. Lists join
+    to CSV exactly like the host's yaml→env bridges do."""
+    for sec in _sections(cfg, section):
+        v = sec.get(cfg_key)
+        if v is None or v == "":
+            continue
+        if isinstance(v, list):
+            return ",".join(str(x) for x in v)
+        return str(v)
     v = os.environ.get(env_key)
-    if v not in (None, ""):
-        return v
-    sec = (cfg or {}).get(section) or {}
-    if isinstance(sec, dict) and sec.get(cfg_key) not in (None, ""):
-        return str(sec.get(cfg_key))
-    return None
+    return v if v not in (None, "") else None
 
 
 def _platform_config_problems(cfg) -> list:
@@ -65,28 +81,43 @@ def _platform_config_problems(cfg) -> list:
     if env.get("TELEGRAM_BOT_TOKEN"):
         raw = _resolve("TELEGRAM_GROUP_ALLOWED_CHATS", cfg, "telegram", "group_allowed_chats") or ""
         chats = [c.strip() for c in raw.split(",") if c.strip()]
-        users = _resolve("TELEGRAM_GROUP_ALLOWED_USERS", cfg, "telegram", "group_allowed_users")
-        if not chats and not users:
-            out.append("Telegram: no group authorized (TELEGRAM_GROUP_ALLOWED_CHATS empty) — the bot "
-                       "IGNORES every group message. Add the group's chat id (negative) or '*'.")
+        if not chats:
+            # User-level allowlists don't substitute: group OBSERVATION (what
+            # turn-taking runs on) requires an explicit chat allowlist in the
+            # host — with only user auth the bot answers direct @mentions but
+            # never sees the group's conversation stream.
+            out.append("Telegram: TELEGRAM_GROUP_ALLOWED_CHATS is empty — the bot cannot observe "
+                       "group conversation, so group turn-taking is OFF (at most it answers direct "
+                       "@mentions from allowed users). Add each group's chat id (negative, e.g. -100…).")
         for c in chats:
-            if c != "*" and not (c.startswith("-") and c[1:].isdigit()):
-                out.append(f"Telegram: TELEGRAM_GROUP_ALLOWED_CHATS entry '{c}' is not a group id "
-                           "(group ids are negative, e.g. -100…) — that entry authorizes nothing.")
+            if not (c.startswith("-") and c[1:].isdigit()):
+                out.append(f"Telegram: TELEGRAM_GROUP_ALLOWED_CHATS entry '{c}' is not a group id — "
+                           "Hermes matches chat ids literally ('*' does not work here; group ids are "
+                           "negative, e.g. -100…), so that entry authorizes nothing.")
 
-    # ── Slack (in use if a token is set) ──
+    # ── Slack (in use if a token is set; user auth is env-only in the host) ──
     if env.get("SLACK_BOT_TOKEN") or env.get("SLACK_APP_TOKEN"):
-        if env.get("SLACK_ALLOW_ALL_USERS", "").lower() not in _TRUE and not env.get("SLACK_ALLOWED_USERS", "").strip():
-            out.append("Slack: no user authorized — the bot IGNORES everyone. "
-                       "Set SLACK_ALLOW_ALL_USERS=true, or list SLACK_ALLOWED_USERS.")
+        allow_all = any(env.get(k, "").strip().lower() in _HOST_TRUE
+                        for k in ("SLACK_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS"))
+        listed = env.get("SLACK_ALLOWED_USERS", "").strip() or env.get("GATEWAY_ALLOWED_USERS", "").strip()
+        if not allow_all and not listed:
+            out.append("Slack: no user authorized — the bot ignores everyone except already-paired "
+                       "users. Set SLACK_ALLOW_ALL_USERS=true, or list SLACK_ALLOWED_USERS.")
+        for k in ("SLACK_ALLOW_ALL_USERS", "GATEWAY_ALLOW_ALL_USERS"):
+            v = env.get(k, "").strip().lower()
+            if v and v not in _HOST_TRUE and v not in _FALSE:
+                out.append(f"Slack: {k}='{v}' is not a value Hermes accepts (true/1/yes) — "
+                           "it is treated as OFF.")
         mention = (_resolve("SLACK_REQUIRE_MENTION", cfg, "slack", "require_mention") or "").lower()
         free = _resolve("SLACK_FREE_RESPONSE_CHANNELS", cfg, "slack", "free_response_channels")
         if mention not in _FALSE and not free:
             out.append("Slack: the bot only replies when @mentioned in channels. Set "
                        "SLACK_REQUIRE_MENTION=false (or SLACK_FREE_RESPONSE_CHANNELS) to answer unmentioned messages.")
 
-    # ── WhatsApp (in use if any WHATSAPP_* var is set) ──
-    if any(k.startswith("WHATSAPP_") for k in env):
+    # ── WhatsApp (in use only when the host would enable it: WHATSAPP_ENABLED
+    # truthy — WHATSAPP_ENABLED=false or WHATSAPP_CLOUD_* alone don't count) ──
+    wa_enabled = (_resolve("WHATSAPP_ENABLED", cfg, "whatsapp", "enabled") or "").strip().lower()
+    if wa_enabled in _HOST_TRUE:
         policy = (_resolve("WHATSAPP_GROUP_POLICY", cfg, "whatsapp", "group_policy") or "").lower()
         if policy and policy not in {"open", "allowlist", "disabled", "pairing"}:
             out.append(f"WhatsApp: WHATSAPP_GROUP_POLICY='{policy}' is not valid "
@@ -101,19 +132,38 @@ def _platform_config_problems(cfg) -> list:
     return out
 
 
-def _should_chat_warn() -> bool:
-    """Chat-warn about config exactly ONCE ever (until the marker file is
-    removed), then never again — a deliberate setup shouldn't be nagged for
-    eternity. Only called when there ARE problems, so the marker is written the
-    first time we'd actually warn. Logs still fire every boot regardless."""
-    marker = Path.home() / ".hermes" / ".turn_taking_config_warned"
-    if marker.exists():
-        return False
+def _marker_path() -> Path:
+    """Chat-warn marker in the real hermes home (HERMES_HOME-aware); falls
+    back to ~/.hermes when hermes_constants isn't importable."""
     try:
-        marker.write_text("1")
+        from hermes_constants import get_hermes_home  # noqa: PLC0415
+        return Path(get_hermes_home()) / ".turn_taking_config_warned"
+    except Exception:
+        return Path.home() / ".hermes" / ".turn_taking_config_warned"
+
+
+def _should_chat_warn(digest: str) -> bool:
+    """Chat-warn once per distinct problem set: the marker holds the digest of
+    the problems that were actually DELIVERED to a home chat (see
+    _mark_chat_warned). The same set stays silent — a deliberate setup isn't
+    nagged — but any new or changed problem warns again. Logs still fire every
+    boot regardless."""
+    try:
+        return _marker_path().read_text().strip() != digest
+    except Exception:
+        return True
+
+
+def _mark_chat_warned(digest: str) -> None:
+    """Delivery callback from notify: record WHAT was warned about, only once
+    the message really reached a home chat. Queued-but-undelivered warnings
+    (URL unset, CLI process, no /sethome yet) keep re-queueing until seen."""
+    try:
+        p = _marker_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(digest)
     except Exception:
         pass  # best-effort; worst case the warning repeats, never lost
-    return True
 
 
 def _warn_misconfig() -> None:
@@ -121,8 +171,10 @@ def _warn_misconfig() -> None:
     answer nowhere. Two families: plugin-core (URL/key/streaming/group_sessions
     — the plugin can't work) and per-platform auth/mention (it connects but
     ignores messages). Logged in full on every start; pushed to the home chat
-    only the FIRST time (see _should_chat_warn), so a deliberate setup isn't
-    nagged forever. URL-unset stays log-only (no inbound path to flush).
+    once per distinct problem set, and only counted as warned when actually
+    delivered (see _should_chat_warn/_mark_chat_warned). While URL is unset the
+    push stays queued (no inbound path installs), so it arrives — not is lost —
+    once the plugin is configured.
     """
     problems = []
     if not _config.service_url():
@@ -152,8 +204,13 @@ def _warn_misconfig() -> None:
     problems += _platform_config_problems(cfg)
     for p in problems:
         _log.warning("turn-taking: %s", p)
-    if problems and _should_chat_warn():
-        notify.queue_startup("⚠️ turn-taking / platform config:\n• " + "\n• ".join(problems))
+    if problems:
+        digest = hashlib.sha256("\n".join(sorted(problems)).encode()).hexdigest()
+        if _should_chat_warn(digest):
+            notify.queue_startup(
+                "⚠️ turn-taking / platform config:\n• " + "\n• ".join(problems),
+                on_delivered=lambda: _mark_chat_warned(digest),
+            )
 
 
 def register(ctx) -> None:

--- a/__init__.py
+++ b/__init__.py
@@ -31,7 +31,6 @@ from .turn_taking.patching import (
     _patch_telegram_observe_group,
 )
 from .turn_taking import notify
-from .turn_taking.service import _service_url
 
 _log = logging.getLogger(__name__)
 
@@ -278,8 +277,13 @@ def register(ctx) -> None:
         social_learning.warm_recent_sessions()
     except Exception as e:
         _log.warning("turn-taking: social-learning warm-up skipped: %s", e)
-    if not _service_url():
-        return  # already warned loudly in _warn_misconfig()
+    if not login.has_working_key():
+        # No usable API key → turn-taking stays a no-op this boot (the login
+        # popped above drives connection; /soul and the social-learning hook,
+        # which self-gate on the key, are already registered). Patches install
+        # on the next boot once a working key is in .env.
+        _log.info("turn-taking: no working API key yet — patches not installed this boot")
+        return
     sent = _patch_send()
     inbound = _patch__enqueue_text_event()
     poll = _patch__poll_messages()

--- a/__init__.py
+++ b/__init__.py
@@ -192,7 +192,11 @@ def _warn_misconfig() -> None:
     try:
         import yaml
 
-        cfg = yaml.safe_load((Path.home() / ".hermes" / "config.yaml").read_text()) or {}
+        # Same HERMES_HOME-aware path autoconfig WRITES to — a hardcoded
+        # ~/.hermes here reads a stray/empty file under a relocated home (Docker
+        # HERMES_HOME=/opt/data, Windows), warning about config that is actually
+        # correct on disk. login._hermes_home() is the host's own resolver.
+        cfg = yaml.safe_load((login._hermes_home() / "config.yaml").read_text()) or {}
     except FileNotFoundError:
         cfg = {}
     except Exception as e:

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ import logging
 import os
 from pathlib import Path
 
-from . import _config, connect, social_learning, soul
+from . import _config, connect, login, social_learning, soul
 from .turn_taking.hooks import on_transform_llm_output
 from .turn_taking.patching import (
     _patch__enqueue_text_event,
@@ -222,6 +222,13 @@ def register(ctx) -> None:
     the turn-taking service).
     """
     _warn_misconfig()
+    try:
+        # First keyless boot: pop the device-auth login once (browser tab on a
+        # desktop, printed URL on the gateway console otherwise) so a fresh
+        # install connects immediately. /connect and login.py are the retries.
+        login.maybe_first_boot_login()
+    except Exception as e:
+        _log.warning("turn-taking: first-boot login skipped: %s", e)
     try:
         ctx.register_command(
             "soul", soul.command,

--- a/__init__.py
+++ b/__init__.py
@@ -178,8 +178,8 @@ def _warn_misconfig() -> None:
     """
     problems = []
     if not _config.service_url():
-        problems.append("HUMALIKE_API_URL is not set — turn-taking is DISABLED "
-                        "(/soul still works). Add it to ~/.hermes/.env.")
+        problems.append("HUMALIKE_API_URL is set empty — turn-taking is explicitly "
+                        "DISABLED (/soul still works).")
     elif not _config.api_key():
         problems.append("HUMALIKE_API_KEY is not set — every Humalike call will "
                         "fail with 401. Send the bot /connect to link your "
@@ -216,10 +216,10 @@ def _warn_misconfig() -> None:
 def register(ctx) -> None:
     """Plugin entry point: activate the send + inbound patches.
 
-    Idle (no patching) when turn-taking isn't configured, so the plugin is a
-    no-op unless ``HUMALIKE_API_URL`` is set — but the ``/soul`` persona
-    command is registered regardless (it uses the separate Personas API, not
-    the turn-taking service).
+    Idle (no patching) only when turn-taking is explicitly disabled
+    (``HUMALIKE_API_URL`` set EMPTY — the URL defaults to the public API
+    otherwise) — the ``/soul`` persona command is registered regardless (it
+    uses the separate Personas API, not the turn-taking service).
     """
     _warn_misconfig()
     try:

--- a/__init__.py
+++ b/__init__.py
@@ -15,6 +15,7 @@ This module only registers the plugin's command, hooks, and patches.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 from . import _config, social_learning, soul
@@ -34,15 +35,94 @@ from .turn_taking.service import _service_url
 _log = logging.getLogger(__name__)
 
 
-def _warn_misconfig() -> None:
-    """Fail loudly at startup on every misconfig that otherwise breaks silently.
+_TRUE = {"true", "1", "yes", "on"}
+_FALSE = {"false", "0", "no", "off"}
 
-    Each case produces broken behavior with no error near the cause (silent
-    idle, 401s, per-user group sessions, streamed replies the plugin can't
-    replace). Every problem is logged AND queued for the home chat, delivered on
-    the first inbound message (adapters aren't connected yet here) — except when
-    HUMALIKE_API_URL is unset, which leaves turn-taking off and no inbound path
-    to flush through, so that one stays log-only.
+
+def _resolve(env_key: str, cfg, section: str, cfg_key: str):
+    """A platform setting as the host resolves it: env var wins, else the
+    ``config.yaml`` platform-section key, else None. Checking both keeps us from
+    warning about something the operator set in yaml instead of env."""
+    v = os.environ.get(env_key)
+    if v not in (None, ""):
+        return v
+    sec = (cfg or {}).get(section) or {}
+    if isinstance(sec, dict) and sec.get(cfg_key) not in (None, ""):
+        return str(sec.get(cfg_key))
+    return None
+
+
+def _platform_config_problems(cfg) -> list:
+    """How each connected platform will behave given its auth/mention config —
+    surfaced when the bot will answer nowhere you'd expect. Only for platforms
+    actually in use (token/vars present), read from env AND config.yaml. Framed
+    as behaviour, not error: the fully-open setup is a choice, so this informs.
+    """
+    env = os.environ
+    out = []
+
+    # ── Telegram (in use if a bot token is set) ──
+    if env.get("TELEGRAM_BOT_TOKEN"):
+        raw = _resolve("TELEGRAM_GROUP_ALLOWED_CHATS", cfg, "telegram", "group_allowed_chats") or ""
+        chats = [c.strip() for c in raw.split(",") if c.strip()]
+        users = _resolve("TELEGRAM_GROUP_ALLOWED_USERS", cfg, "telegram", "group_allowed_users")
+        if not chats and not users:
+            out.append("Telegram: no group authorized (TELEGRAM_GROUP_ALLOWED_CHATS empty) — the bot "
+                       "IGNORES every group message. Add the group's chat id (negative) or '*'.")
+        for c in chats:
+            if c != "*" and not (c.startswith("-") and c[1:].isdigit()):
+                out.append(f"Telegram: TELEGRAM_GROUP_ALLOWED_CHATS entry '{c}' is not a group id "
+                           "(group ids are negative, e.g. -100…) — that entry authorizes nothing.")
+
+    # ── Slack (in use if a token is set) ──
+    if env.get("SLACK_BOT_TOKEN") or env.get("SLACK_APP_TOKEN"):
+        if env.get("SLACK_ALLOW_ALL_USERS", "").lower() not in _TRUE and not env.get("SLACK_ALLOWED_USERS", "").strip():
+            out.append("Slack: no user authorized — the bot IGNORES everyone. "
+                       "Set SLACK_ALLOW_ALL_USERS=true, or list SLACK_ALLOWED_USERS.")
+        mention = (_resolve("SLACK_REQUIRE_MENTION", cfg, "slack", "require_mention") or "").lower()
+        free = _resolve("SLACK_FREE_RESPONSE_CHANNELS", cfg, "slack", "free_response_channels")
+        if mention not in _FALSE and not free:
+            out.append("Slack: the bot only replies when @mentioned in channels. Set "
+                       "SLACK_REQUIRE_MENTION=false (or SLACK_FREE_RESPONSE_CHANNELS) to answer unmentioned messages.")
+
+    # ── WhatsApp (in use if any WHATSAPP_* var is set) ──
+    if any(k.startswith("WHATSAPP_") for k in env):
+        policy = (_resolve("WHATSAPP_GROUP_POLICY", cfg, "whatsapp", "group_policy") or "").lower()
+        if policy and policy not in {"open", "allowlist", "disabled", "pairing"}:
+            out.append(f"WhatsApp: WHATSAPP_GROUP_POLICY='{policy}' is not valid "
+                       "(open|allowlist|disabled|pairing) — likely a typo; groups may be blocked.")
+        elif policy in ("", "pairing"):
+            out.append("WhatsApp: group policy is 'pairing' (the default) — the bot will NOT answer in "
+                       "groups until each is paired. Set WHATSAPP_GROUP_POLICY=open to answer in all groups.")
+        wrm = (_resolve("WHATSAPP_REQUIRE_MENTION", cfg, "whatsapp", "require_mention") or "").lower()
+        if wrm and wrm not in _FALSE:
+            out.append("WhatsApp: WHATSAPP_REQUIRE_MENTION is on — the bot only replies when @mentioned.")
+
+    return out
+
+
+def _should_chat_warn() -> bool:
+    """Chat-warn about config exactly ONCE ever (until the marker file is
+    removed), then never again — a deliberate setup shouldn't be nagged for
+    eternity. Only called when there ARE problems, so the marker is written the
+    first time we'd actually warn. Logs still fire every boot regardless."""
+    marker = Path.home() / ".hermes" / ".turn_taking_config_warned"
+    if marker.exists():
+        return False
+    try:
+        marker.write_text("1")
+    except Exception:
+        pass  # best-effort; worst case the warning repeats, never lost
+    return True
+
+
+def _warn_misconfig() -> None:
+    """Warn about config that silently breaks turn-taking or makes the bot
+    answer nowhere. Two families: plugin-core (URL/key/streaming/group_sessions
+    — the plugin can't work) and per-platform auth/mention (it connects but
+    ignores messages). Logged in full on every start; pushed to the home chat
+    only the FIRST time (see _should_chat_warn), so a deliberate setup isn't
+    nagged forever. URL-unset stays log-only (no inbound path to flush).
     """
     problems = []
     if not _config.service_url():
@@ -68,10 +148,11 @@ def _warn_misconfig() -> None:
         if cfg.get("group_sessions_per_user", True):  # Hermes defaults this to true
             problems.append("group_sessions_per_user is not false — set "
                             "'group_sessions_per_user: false' (group chats need one shared thread).")
+    problems += _platform_config_problems(cfg)
     for p in problems:
         _log.warning("turn-taking: %s", p)
-    if problems:
-        notify.queue_startup("⚠️ turn-taking misconfigured:\n• " + "\n• ".join(problems))
+    if problems and _should_chat_warn():
+        notify.queue_startup("⚠️ turn-taking / platform config:\n• " + "\n• ".join(problems))
 
 
 def register(ctx) -> None:
@@ -106,6 +187,10 @@ def register(ctx) -> None:
         _log.info("turn-taking: registered social-learning pre_llm_call hook")
     except Exception as e:
         _log.warning("turn-taking: could not register social-learning hook: %s", e)
+    try:
+        social_learning.warm_recent_sessions()
+    except Exception as e:
+        _log.warning("turn-taking: social-learning warm-up skipped: %s", e)
     if not _service_url():
         return  # already warned loudly in _warn_misconfig()
     sent = _patch_send()

--- a/_config.py
+++ b/_config.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import os
 
 
+DEFAULT_API = "https://api.humalike.com"
+
+
 def service_url() -> str:
-    """Base URL for all Humalike calls (``HUMALIKE_API_URL``)."""
-    return os.getenv("HUMALIKE_API_URL", "").rstrip("/")
+    """Base URL for all Humalike calls (``HUMALIKE_API_URL``). Defaults to the
+    public API so a fresh install needs zero env setup; set it EMPTY
+    (``HUMALIKE_API_URL=``) to explicitly disable turn-taking."""
+    return os.getenv("HUMALIKE_API_URL", DEFAULT_API).rstrip("/")
 
 
 def api_key() -> str:

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -122,11 +122,12 @@ def plan(cfg: dict, env: dict, done: set) -> tuple[dict, dict, list, list, list]
         if wa_fixes:
             # Opening up a messaging number is a behavior change worth a loud
             # word — especially if it's someone's PERSONAL WhatsApp.
-            statuses.append(("warn", "WhatsApp will now reply to EVERYONE who messages this "
-                                     "number — DMs and all groups. If this is a personal "
-                                     "number, tighten it in ~/.hermes/.env: "
-                                     "WHATSAPP_ALLOW_ALL_USERS=false (paired users only) "
-                                     "and/or WHATSAPP_GROUP_POLICY=allowlist."))
+            statuses.append(("warn",
+                             "WHATSAPP WILL NOW REPLY TO EVERYONE WHO MESSAGES THIS NUMBER — "
+                             "DMS AND ALL GROUPS.\n"
+                             "  If this is a personal number, tighten it in ~/.hermes/.env: "
+                             "WHATSAPP_ALLOW_ALL_USERS=false (paired users only) and/or "
+                             "WHATSAPP_GROUP_POLICY=allowlist."))
         else:
             statuses.append(("ok", "WhatsApp"))
 
@@ -235,16 +236,21 @@ def maybe_autoconfigure() -> None:
     if not statuses and not todos:
         return
 
-    any_fixed = any(kind == "fixed" for kind, _ in statuses)
+    # Warnings render LAST — bottom of the whole report, right above the
+    # prompt, where they're hardest to miss.
+    warns = [label for kind, label in statuses if kind == "warn"]
+    body = [(kind, label) for kind, label in statuses if kind != "warn"]
+    any_fixed = any(kind == "fixed" for kind, _ in body)
     header = ("🔧 Humalike plugin — configured hermes for turn-taking:" if any_fixed
               else "✅ Humalike plugin — turn-taking setup verified:")
-    _PREFIX = {"fixed": "• ", "warn": "⚠ ", "ok": "✓ "}
-    lines = [f"   {_PREFIX[kind]}{label}" + (" — already right" if kind == "ok" else "")
-             for kind, label in statuses]
+    lines = [f"   {'• ' if kind == 'fixed' else '✓ '}{label}"
+             + (" — already right" if kind == "ok" else "")
+             for kind, label in body]
     if any_fixed:
         lines.append("   Restart hermes once to apply.")
-    parts = ["\n".join([header] + lines)] if statuses else []
+    parts = ["\n".join([header] + lines)] if body else []
     parts.extend(todos)
+    parts.extend(f"⚠ {w}" for w in warns)
     report = "\n\n" + "\n\n".join(parts) + "\n"
 
     def _announce() -> None:

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -119,7 +119,15 @@ def plan(cfg: dict, env: dict, done: set) -> tuple[dict, dict, list, list, list]
                 statuses.append(("fixed", f"{key}: {_was(env.get(key))} → {value} — {why} (.env)"))
                 wa_fixes += 1
         sections.append("whatsapp")
-        if not wa_fixes:
+        if wa_fixes:
+            # Opening up a messaging number is a behavior change worth a loud
+            # word — especially if it's someone's PERSONAL WhatsApp.
+            statuses.append(("warn", "WhatsApp will now reply to EVERYONE who messages this "
+                                     "number — DMs and all groups. If this is a personal "
+                                     "number, tighten it in ~/.hermes/.env: "
+                                     "WHATSAPP_ALLOW_ALL_USERS=false (paired users only) "
+                                     "and/or WHATSAPP_GROUP_POLICY=allowlist."))
+        else:
             statuses.append(("ok", "WhatsApp"))
 
     # ── Slack: respond to everyone (same only-if-unset rule), plus the one
@@ -220,6 +228,8 @@ def maybe_autoconfigure() -> None:
     for kind, label in statuses:
         if kind == "fixed":
             _log.warning("turn-taking: autoconfigured %s", label)
+        elif kind == "warn":
+            _log.warning("turn-taking: %s", label)
         else:
             _log.info("turn-taking: autoconfig verified %s — already right", label)
     if not statuses and not todos:
@@ -228,8 +238,8 @@ def maybe_autoconfigure() -> None:
     any_fixed = any(kind == "fixed" for kind, _ in statuses)
     header = ("🔧 Humalike plugin — configured hermes for turn-taking:" if any_fixed
               else "✅ Humalike plugin — turn-taking setup verified:")
-    lines = [f"   {'•' if kind == 'fixed' else '✓'} {label}"
-             + ("" if kind == "fixed" else " — already right")
+    _PREFIX = {"fixed": "• ", "warn": "⚠ ", "ok": "✓ "}
+    lines = [f"   {_PREFIX[kind]}{label}" + (" — already right" if kind == "ok" else "")
              for kind, label in statuses]
     if any_fixed:
         lines.append("   Restart hermes once to apply.")

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -3,12 +3,14 @@
 Applies the deterministic parts of the install/configure skills so a fresh
 install needs no hand-editing (the same zero-config principle as login.py):
 
-* ``~/.hermes/config.yaml`` — the settings the plugin REQUIRES to own the
-  reply: ``streaming: false``, ``group_sessions_per_user: false``,
-  ``display.tool_progress: "off"`` (install-turn-taking step 3).
-* ``~/.hermes/.env`` — respond-to-everyone settings for platforms actually in
-  use, only where the operator hasn't set a value: WhatsApp
-  (configure-whatsapp-group) and Slack (configure-slack-group).
+* ``config.yaml`` — the settings the plugin REQUIRES to own the reply:
+  ``streaming: false``, ``group_sessions_per_user: false``,
+  ``display.tool_progress: "off"`` (install-turn-taking step 3), and
+  ``slack.reply_in_thread: false`` when Slack is in use (the default trues it,
+  making every top-level channel message its own thread AND session).
+* ``.env`` — respond-to-everyone settings for platforms actually in use, only
+  where the operator hasn't set a value: WhatsApp (configure-whatsapp-group)
+  and Slack (configure-slack-group).
 * Telegram can't be automated — BotFather's privacy toggle is external and
   group chat ids are unknowable — so those two steps are prompted instead
   (configure-telegram-group).
@@ -16,8 +18,11 @@ install needs no hand-editing (the same zero-config principle as login.py):
 Each section applies ONCE (the marker file lists finished sections), so an
 operator who later overrides a value isn't fought every boot — but adding a
 new platform later still triggers just that platform's section. The report is
-shown TUI-safely via login._show once the TUI is up. config.yaml is rewritten
-via yaml round-trip; comments there are lost — keys and values are preserved.
+granular and TUI-safe (login._show): every swept section shows its status —
+``✓`` already right, ``•`` fixed, ``📋`` manual steps — so the operator always
+sees what was checked, not just what changed. Normal boots (marker complete)
+stay silent. config.yaml is rewritten via yaml round-trip; comments there are
+lost — keys and values are preserved.
 """
 
 from __future__ import annotations
@@ -59,26 +64,31 @@ _TELEGRAM_TODO = (
 def plan(cfg: dict, env: dict, done: set) -> tuple[dict, dict, list, list, list]:
     """Decide what's left to configure. Pure — takes the current config.yaml
     dict, a merged env view, and the already-done sections; returns
-    ``(config_updates, env_updates, notes, todos, sections)``."""
+    ``(config_updates, env_updates, statuses, todos, sections)`` where
+    ``statuses`` is ``[("fixed"|"ok", label), …]`` — one entry per swept
+    section, so the report can show verified items, not just changed ones."""
     config_updates: dict = {}
     env_updates: dict = {}
-    notes: list = []
+    statuses: list = []
     todos: list = []
     sections: list = []
 
     # ── Core chat settings (required — fixed even if set the wrong way) ──
     if "core" not in done:
+        fixes = []
         if cfg.get("streaming") is not False:
             config_updates["streaming"] = False
+            fixes.append("streaming off")
         if cfg.get("group_sessions_per_user") is not False:
             config_updates["group_sessions_per_user"] = False
+            fixes.append("one shared thread per group")
         display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
         if display.get("tool_progress") != "off":
             config_updates["display"] = {**display, "tool_progress": "off"}
+            fixes.append("tool-call chatter hidden")
         sections.append("core")
-        if config_updates:
-            notes.append("core chat settings — streaming off, one shared thread per "
-                         "group, tool-call chatter hidden")
+        statuses.append(("fixed", "chat settings — " + ", ".join(fixes)) if fixes
+                        else ("ok", "chat settings"))
 
     # ── WhatsApp: respond to everyone (only fills keys the operator left unset) ──
     if "whatsapp" not in done and (env.get("WHATSAPP_ENABLED") or "").lower() in _TRUE:
@@ -88,8 +98,9 @@ def plan(cfg: dict, env: dict, done: set) -> tuple[dict, dict, list, list, list]
             if not env.get(key):
                 env_updates[key] = value
         sections.append("whatsapp")
-        if any(k.startswith("WHATSAPP") for k in env_updates):
-            notes.append("WhatsApp — respond to everyone, in every group, no @mention")
+        fixed = any(k.startswith("WHATSAPP") for k in env_updates)
+        statuses.append(("fixed", "WhatsApp — respond to everyone, in every group, no @mention")
+                        if fixed else ("ok", "WhatsApp"))
 
     # ── Slack: respond to everyone (same only-if-unset rule), plus the one
     # config.yaml key turn-taking REQUIRES there: reply_in_thread: false —
@@ -104,17 +115,20 @@ def plan(cfg: dict, env: dict, done: set) -> tuple[dict, dict, list, list, list]
         if slack_cfg.get("reply_in_thread") is not False:
             config_updates["slack"] = {**slack_cfg, "reply_in_thread": False}
         sections.append("slack")
-        if any(k.startswith("SLACK") for k in env_updates) or "slack" in config_updates:
-            notes.append("Slack — respond to everyone, no @mention, one shared "
-                         "conversation per channel (reply_in_thread off)")
+        fixed = any(k.startswith("SLACK") for k in env_updates) or "slack" in config_updates
+        statuses.append(("fixed", "Slack — respond to everyone, no @mention, one shared "
+                                  "conversation per channel (reply_in_thread off)")
+                        if fixed else ("ok", "Slack"))
 
     # ── Telegram: prompt-only (once) ──
     if "telegram" not in done and env.get("TELEGRAM_BOT_TOKEN"):
         sections.append("telegram")
         if not env.get("TELEGRAM_GROUP_ALLOWED_CHATS"):
             todos.append(_TELEGRAM_TODO)
+        else:
+            statuses.append(("ok", "Telegram"))
 
-    return config_updates, env_updates, notes, todos, sections
+    return config_updates, env_updates, statuses, todos, sections
 
 
 def _merged_env() -> dict:
@@ -144,7 +158,7 @@ def maybe_autoconfigure() -> None:
         _log.warning("turn-taking: autoconfig cannot read %s (%s) — config part skipped", _CONFIG, e)
         cfg_writable = False
 
-    config_updates, env_updates, notes, todos, sections = plan(cfg, _merged_env(), done)
+    config_updates, env_updates, statuses, todos, sections = plan(cfg, _merged_env(), done)
     if not sections:
         return
 
@@ -157,8 +171,8 @@ def maybe_autoconfigure() -> None:
             _CONFIG.write_text(yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True))
         except Exception as e:
             _log.warning("turn-taking: autoconfig could not write %s: %s", _CONFIG, e)
-            notes = [n for n in notes if not n.startswith("core chat settings")]
             sections = [s for s in sections if s != "core"]  # retry next boot
+            statuses = [s for s in statuses if not s[1].startswith("chat settings")]
     if env_updates:
         try:
             login.upsert_env(login.HERMES_ENV, env_updates)
@@ -172,27 +186,25 @@ def maybe_autoconfigure() -> None:
     except Exception:
         pass  # best-effort; worst case a section re-applies (it is idempotent)
 
-    for note in notes:
-        _log.warning("turn-taking: autoconfigured %s", note)
+    for kind, label in statuses:
+        if kind == "fixed":
+            _log.warning("turn-taking: autoconfigured %s", label)
+        else:
+            _log.info("turn-taking: autoconfig verified %s — already right", label)
+    if not statuses and not todos:
+        return
 
-    if notes or todos:
-        parts = []
-        if notes:
-            parts.append("🔧 Humalike plugin — configured hermes for turn-taking:\n"
-                         + "\n".join(f"   • {n}" for n in notes)
-                         + "\n   Restart hermes once to apply.")
-        parts.extend(todos)
-        report = "\n\n" + "\n\n".join(parts) + "\n"
-    else:
-        # Nothing needed changing — still confirm ONCE (a sweep only runs when
-        # the marker was missing): a fresh or re-armed install should get
-        # positive confirmation, not silence that reads as failure.
-        names = {"core": "chat settings", "whatsapp": "WhatsApp", "slack": "Slack",
-                 "telegram": "Telegram"}
-        checked = ", ".join(names.get(s, s) for s in sections)
-        report = (f"\n✅ Humalike plugin — hermes is already configured for "
-                  f"turn-taking (checked: {checked}).\n")
-        _log.info("turn-taking: autoconfig verified — nothing to change (%s)", checked)
+    any_fixed = any(kind == "fixed" for kind, _ in statuses)
+    header = ("🔧 Humalike plugin — configured hermes for turn-taking:" if any_fixed
+              else "✅ Humalike plugin — turn-taking setup verified:")
+    lines = [f"   {'•' if kind == 'fixed' else '✓'} {label}"
+             + ("" if kind == "fixed" else " — already right")
+             for kind, label in statuses]
+    if any_fixed:
+        lines.append("   Restart hermes once to apply.")
+    parts = ["\n".join([header] + lines)] if statuses else []
+    parts.extend(todos)
+    report = "\n\n" + "\n\n".join(parts) + "\n"
 
     def _announce() -> None:
         login._wait_for_tui()

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -31,8 +31,10 @@ from . import login
 
 _log = logging.getLogger(__name__)
 
-_MARKER = Path.home() / ".hermes" / ".turn_taking_autoconfigured"
-_CONFIG = Path.home() / ".hermes" / "config.yaml"
+# Resolved through the host's own HERMES_HOME-aware resolver (login._hermes_home)
+# so a relocated install gets its REAL files updated, not a stray ~/.hermes.
+_MARKER = login._hermes_home() / ".turn_taking_autoconfigured"
+_CONFIG = login._hermes_home() / "config.yaml"
 
 _TRUE = {"true", "1", "yes"}  # the host's truthy set for enable flags
 

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -245,8 +245,10 @@ def maybe_autoconfigure() -> None:
     warns = [label for kind, label in statuses if kind == "warn"]
     body = [(kind, label) for kind, label in statuses if kind != "warn"]
     any_fixed = any(kind == "fixed" for kind, _ in body)
-    header = ("🔧 Humalike plugin — configured hermes for turn-taking:" if any_fixed
-              else "✅ Humalike plugin — turn-taking setup verified:")
+    header = ("🔧 Humalike plugin — configured hermes for turn-taking:\n"
+              "   DISCLAIMER: this is extra info — no action needed unless a line says so." if any_fixed
+              else "✅ Humalike plugin — turn-taking setup verified:\n"
+                   "   DISCLAIMER: this is extra info — nothing for you to do.")
     lines = [f"   {'• ' if kind == 'fixed' else '✓ '}{label}"
              + (" — already right" if kind == "ok" else "")
              for kind, label in body]

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -61,6 +61,15 @@ _TELEGRAM_TODO = (
 )
 
 
+def _was(value) -> str:
+    """The previous value, human-readable: ``(unset)`` / yaml-style booleans."""
+    if value is None or value == "":
+        return "(unset)"
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
 def plan(cfg: dict, env: dict, done: set) -> tuple[dict, dict, list, list, list]:
     """Decide what's left to configure. Pure — takes the current config.yaml
     dict, a merged env view, and the already-done sections; returns
@@ -78,47 +87,67 @@ def plan(cfg: dict, env: dict, done: set) -> tuple[dict, dict, list, list, list]
         fixes = []
         if cfg.get("streaming") is not False:
             config_updates["streaming"] = False
-            fixes.append("streaming off")
+            fixes.append(f"streaming: {_was(cfg.get('streaming'))} → false — the plugin must "
+                         "own the final reply text (config.yaml)")
         if cfg.get("group_sessions_per_user") is not False:
             config_updates["group_sessions_per_user"] = False
-            fixes.append("one shared thread per group")
+            fixes.append(f"group_sessions_per_user: {_was(cfg.get('group_sessions_per_user'))} "
+                         "→ false — a group chat needs ONE shared conversation, not one per "
+                         "member (config.yaml)")
         display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
         if display.get("tool_progress") != "off":
             config_updates["display"] = {**display, "tool_progress": "off"}
-            fixes.append("tool-call chatter hidden")
+            fixes.append(f"display.tool_progress: {_was(display.get('tool_progress'))} → off — "
+                         "hide tool-call chatter (Browsing/Clicking…) so replies read as human "
+                         "(config.yaml)")
         sections.append("core")
-        statuses.append(("fixed", "chat settings — " + ", ".join(fixes)) if fixes
-                        else ("ok", "chat settings"))
+        statuses.extend(("fixed", f) for f in fixes)
+        if not fixes:
+            statuses.append(("ok", "chat settings"))
 
     # ── WhatsApp: respond to everyone (only fills keys the operator left unset) ──
     if "whatsapp" not in done and (env.get("WHATSAPP_ENABLED") or "").lower() in _TRUE:
-        for key, value in (("WHATSAPP_ALLOW_ALL_USERS", "true"),
-                           ("WHATSAPP_REQUIRE_MENTION", "false"),
-                           ("WHATSAPP_GROUP_POLICY", "open")):
+        wa_fixes = 0
+        for key, value, why in (
+            ("WHATSAPP_ALLOW_ALL_USERS", "true", "reply to any sender, not only paired users"),
+            ("WHATSAPP_REQUIRE_MENTION", "false", "reply without needing an @mention"),
+            ("WHATSAPP_GROUP_POLICY", "open", "answer in every group — the default "
+                                              "'pairing' blocks groups"),
+        ):
             if not env.get(key):
                 env_updates[key] = value
+                statuses.append(("fixed", f"{key}: {_was(env.get(key))} → {value} — {why} (.env)"))
+                wa_fixes += 1
         sections.append("whatsapp")
-        fixed = any(k.startswith("WHATSAPP") for k in env_updates)
-        statuses.append(("fixed", "WhatsApp — respond to everyone, in every group, no @mention")
-                        if fixed else ("ok", "WhatsApp"))
+        if not wa_fixes:
+            statuses.append(("ok", "WhatsApp"))
 
     # ── Slack: respond to everyone (same only-if-unset rule), plus the one
     # config.yaml key turn-taking REQUIRES there: reply_in_thread: false —
     # the default trues it, making every top-level channel message its own
     # thread AND session, so turn-taking can never coalesce a conversation. ──
     if "slack" not in done and (env.get("SLACK_BOT_TOKEN") or env.get("SLACK_APP_TOKEN")):
-        for key, value in (("SLACK_ALLOW_ALL_USERS", "true"),
-                           ("SLACK_REQUIRE_MENTION", "false")):
+        slack_fixes = 0
+        for key, value, why in (
+            ("SLACK_ALLOW_ALL_USERS", "true", "reply to anyone in the workspace"),
+            ("SLACK_REQUIRE_MENTION", "false", "see and answer unmentioned channel messages"),
+        ):
             if not env.get(key):
                 env_updates[key] = value
+                statuses.append(("fixed", f"{key}: {_was(env.get(key))} → {value} — {why} (.env)"))
+                slack_fixes += 1
         slack_cfg = cfg.get("slack") if isinstance(cfg.get("slack"), dict) else {}
         if slack_cfg.get("reply_in_thread") is not False:
             config_updates["slack"] = {**slack_cfg, "reply_in_thread": False}
+            statuses.append(("fixed", "slack.reply_in_thread: "
+                                      f"{_was(slack_cfg.get('reply_in_thread'))} → false — one "
+                                      "shared conversation per channel; the default makes EVERY "
+                                      "message its own thread and session, so the bot answers "
+                                      "each one separately (config.yaml)"))
+            slack_fixes += 1
         sections.append("slack")
-        fixed = any(k.startswith("SLACK") for k in env_updates) or "slack" in config_updates
-        statuses.append(("fixed", "Slack — respond to everyone, no @mention, one shared "
-                                  "conversation per channel (reply_in_thread off)")
-                        if fixed else ("ok", "Slack"))
+        if not slack_fixes:
+            statuses.append(("ok", "Slack"))
 
     # ── Telegram: prompt-only (once) ──
     if "telegram" not in done and env.get("TELEGRAM_BOT_TOKEN"):
@@ -172,7 +201,9 @@ def maybe_autoconfigure() -> None:
         except Exception as e:
             _log.warning("turn-taking: autoconfig could not write %s: %s", _CONFIG, e)
             sections = [s for s in sections if s != "core"]  # retry next boot
-            statuses = [s for s in statuses if not s[1].startswith("chat settings")]
+            statuses = [s for s in statuses
+                        if not s[1].startswith(("streaming:", "group_sessions_per_user:",
+                                                "display.", "slack.reply_in_thread:"))]
     if env_updates:
         try:
             login.upsert_env(login.HERMES_ENV, env_updates)

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -259,8 +259,8 @@ def maybe_autoconfigure() -> None:
         # Closing footer, last line of the whole report: the host reads these
         # settings at startup, so a change made during THIS boot only takes
         # effect on the next one — restart once more after the setup finishes.
-        parts.append("↻ Restart the hermes gateway once more after this setup to load the "
-                     "updated configuration.")
+        parts.append("↻ ACTION REQUIRED — restart the hermes gateway once more after this "
+                     "setup to load the updated configuration.")
     report = "\n\n" + "\n\n".join(parts) + "\n"
 
     def _announce() -> None:

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -52,7 +52,8 @@ _ENV_KEYS = (
 )
 
 _TELEGRAM_TODO = (
-    "📋 Telegram needs two manual steps (they can't be automated):\n"
+    "📋 ACTION REQUIRED — Telegram needs two manual steps from you "
+    "(they can't be automated):\n"
     "   1. @BotFather → /setprivacy → Disable — then remove the bot from the\n"
     "      group and re-add it (the change only applies to a fresh membership).\n"
     "   2. Add the group's chat id to TELEGRAM_GROUP_ALLOWED_CHATS in\n"

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -174,16 +174,25 @@ def maybe_autoconfigure() -> None:
 
     for note in notes:
         _log.warning("turn-taking: autoconfigured %s", note)
-    if not notes and not todos:
-        return
 
-    parts = []
-    if notes:
-        parts.append("🔧 Humalike plugin — configured hermes for turn-taking:\n"
-                     + "\n".join(f"   • {n}" for n in notes)
-                     + "\n   Restart hermes once to apply.")
-    parts.extend(todos)
-    report = "\n\n" + "\n\n".join(parts) + "\n"
+    if notes or todos:
+        parts = []
+        if notes:
+            parts.append("🔧 Humalike plugin — configured hermes for turn-taking:\n"
+                         + "\n".join(f"   • {n}" for n in notes)
+                         + "\n   Restart hermes once to apply.")
+        parts.extend(todos)
+        report = "\n\n" + "\n\n".join(parts) + "\n"
+    else:
+        # Nothing needed changing — still confirm ONCE (a sweep only runs when
+        # the marker was missing): a fresh or re-armed install should get
+        # positive confirmation, not silence that reads as failure.
+        names = {"core": "chat settings", "whatsapp": "WhatsApp", "slack": "Slack",
+                 "telegram": "Telegram"}
+        checked = ", ".join(names.get(s, s) for s in sections)
+        report = (f"\n✅ Humalike plugin — hermes is already configured for "
+                  f"turn-taking (checked: {checked}).\n")
+        _log.info("turn-taking: autoconfig verified — nothing to change (%s)", checked)
 
     def _announce() -> None:
         login._wait_for_tui()

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -91,15 +91,22 @@ def plan(cfg: dict, env: dict, done: set) -> tuple[dict, dict, list, list, list]
         if any(k.startswith("WHATSAPP") for k in env_updates):
             notes.append("WhatsApp — respond to everyone, in every group, no @mention")
 
-    # ── Slack: respond to everyone (same only-if-unset rule) ──
+    # ── Slack: respond to everyone (same only-if-unset rule), plus the one
+    # config.yaml key turn-taking REQUIRES there: reply_in_thread: false —
+    # the default trues it, making every top-level channel message its own
+    # thread AND session, so turn-taking can never coalesce a conversation. ──
     if "slack" not in done and (env.get("SLACK_BOT_TOKEN") or env.get("SLACK_APP_TOKEN")):
         for key, value in (("SLACK_ALLOW_ALL_USERS", "true"),
                            ("SLACK_REQUIRE_MENTION", "false")):
             if not env.get(key):
                 env_updates[key] = value
+        slack_cfg = cfg.get("slack") if isinstance(cfg.get("slack"), dict) else {}
+        if slack_cfg.get("reply_in_thread") is not False:
+            config_updates["slack"] = {**slack_cfg, "reply_in_thread": False}
         sections.append("slack")
-        if any(k.startswith("SLACK") for k in env_updates):
-            notes.append("Slack — respond to everyone, no @mention needed")
+        if any(k.startswith("SLACK") for k in env_updates) or "slack" in config_updates:
+            notes.append("Slack — respond to everyone, no @mention, one shared "
+                         "conversation per channel (reply_in_thread off)")
 
     # ── Telegram: prompt-only (once) ──
     if "telegram" not in done and env.get("TELEGRAM_BOT_TOKEN"):

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -247,8 +247,7 @@ def maybe_autoconfigure() -> None:
     any_fixed = any(kind == "fixed" for kind, _ in body)
     header = ("🔧 Humalike plugin — configured hermes for turn-taking:\n"
               "   DISCLAIMER: this is extra info — no action needed unless a line says so." if any_fixed
-              else "✅ Humalike plugin — turn-taking setup verified:\n"
-                   "   DISCLAIMER: this is extra info — nothing for you to do.")
+              else "✅ Humalike plugin — turn-taking setup verified:")
     lines = [f"   {'• ' if kind == 'fixed' else '✓ '}{label}"
              + (" — already right" if kind == "ok" else "")
              for kind, label in body]

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -1,0 +1,183 @@
+"""First-boot self-configuration — hermes configures itself for turn-taking.
+
+Applies the deterministic parts of the install/configure skills so a fresh
+install needs no hand-editing (the same zero-config principle as login.py):
+
+* ``~/.hermes/config.yaml`` — the settings the plugin REQUIRES to own the
+  reply: ``streaming: false``, ``group_sessions_per_user: false``,
+  ``display.tool_progress: "off"`` (install-turn-taking step 3).
+* ``~/.hermes/.env`` — respond-to-everyone settings for platforms actually in
+  use, only where the operator hasn't set a value: WhatsApp
+  (configure-whatsapp-group) and Slack (configure-slack-group).
+* Telegram can't be automated — BotFather's privacy toggle is external and
+  group chat ids are unknowable — so those two steps are prompted instead
+  (configure-telegram-group).
+
+Each section applies ONCE (the marker file lists finished sections), so an
+operator who later overrides a value isn't fought every boot — but adding a
+new platform later still triggers just that platform's section. The report is
+shown TUI-safely via login._show once the TUI is up. config.yaml is rewritten
+via yaml round-trip; comments there are lost — keys and values are preserved.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+
+from . import login
+
+_log = logging.getLogger(__name__)
+
+_MARKER = Path.home() / ".hermes" / ".turn_taking_autoconfigured"
+_CONFIG = Path.home() / ".hermes" / "config.yaml"
+
+_TRUE = {"true", "1", "yes"}  # the host's truthy set for enable flags
+
+# Every env key the planner reads or writes (env wins over ~/.hermes/.env).
+_ENV_KEYS = (
+    "WHATSAPP_ENABLED", "WHATSAPP_ALLOW_ALL_USERS", "WHATSAPP_REQUIRE_MENTION",
+    "WHATSAPP_GROUP_POLICY",
+    "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOW_ALL_USERS", "SLACK_REQUIRE_MENTION",
+    "TELEGRAM_BOT_TOKEN", "TELEGRAM_GROUP_ALLOWED_CHATS",
+)
+
+_TELEGRAM_TODO = (
+    "📋 Telegram needs two manual steps (they can't be automated):\n"
+    "   1. @BotFather → /setprivacy → Disable — then remove the bot from the\n"
+    "      group and re-add it (the change only applies to a fresh membership).\n"
+    "   2. Add the group's chat id to TELEGRAM_GROUP_ALLOWED_CHATS in\n"
+    "      ~/.hermes/.env (find it in the logs: \"tt inbound: chat=-100…\";\n"
+    "      each group has its own id)."
+)
+
+
+def plan(cfg: dict, env: dict, done: set) -> tuple[dict, dict, list, list, list]:
+    """Decide what's left to configure. Pure — takes the current config.yaml
+    dict, a merged env view, and the already-done sections; returns
+    ``(config_updates, env_updates, notes, todos, sections)``."""
+    config_updates: dict = {}
+    env_updates: dict = {}
+    notes: list = []
+    todos: list = []
+    sections: list = []
+
+    # ── Core chat settings (required — fixed even if set the wrong way) ──
+    if "core" not in done:
+        if cfg.get("streaming") is not False:
+            config_updates["streaming"] = False
+        if cfg.get("group_sessions_per_user") is not False:
+            config_updates["group_sessions_per_user"] = False
+        display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
+        if display.get("tool_progress") != "off":
+            config_updates["display"] = {**display, "tool_progress": "off"}
+        sections.append("core")
+        if config_updates:
+            notes.append("core chat settings — streaming off, one shared thread per "
+                         "group, tool-call chatter hidden")
+
+    # ── WhatsApp: respond to everyone (only fills keys the operator left unset) ──
+    if "whatsapp" not in done and (env.get("WHATSAPP_ENABLED") or "").lower() in _TRUE:
+        for key, value in (("WHATSAPP_ALLOW_ALL_USERS", "true"),
+                           ("WHATSAPP_REQUIRE_MENTION", "false"),
+                           ("WHATSAPP_GROUP_POLICY", "open")):
+            if not env.get(key):
+                env_updates[key] = value
+        sections.append("whatsapp")
+        if any(k.startswith("WHATSAPP") for k in env_updates):
+            notes.append("WhatsApp — respond to everyone, in every group, no @mention")
+
+    # ── Slack: respond to everyone (same only-if-unset rule) ──
+    if "slack" not in done and (env.get("SLACK_BOT_TOKEN") or env.get("SLACK_APP_TOKEN")):
+        for key, value in (("SLACK_ALLOW_ALL_USERS", "true"),
+                           ("SLACK_REQUIRE_MENTION", "false")):
+            if not env.get(key):
+                env_updates[key] = value
+        sections.append("slack")
+        if any(k.startswith("SLACK") for k in env_updates):
+            notes.append("Slack — respond to everyone, no @mention needed")
+
+    # ── Telegram: prompt-only (once) ──
+    if "telegram" not in done and env.get("TELEGRAM_BOT_TOKEN"):
+        sections.append("telegram")
+        if not env.get("TELEGRAM_GROUP_ALLOWED_CHATS"):
+            todos.append(_TELEGRAM_TODO)
+
+    return config_updates, env_updates, notes, todos, sections
+
+
+def _merged_env() -> dict:
+    file_env = login.read_env_file()
+    return {k: os.getenv(k) or file_env.get(k, "") for k in _ENV_KEYS}
+
+
+def maybe_autoconfigure() -> None:
+    """Apply whatever plan() says is left, record it, and report TUI-safely."""
+    try:
+        done = set(_MARKER.read_text().split()) if _MARKER.exists() else set()
+    except Exception:
+        done = set()
+
+    cfg: dict = {}
+    cfg_writable = True
+    try:
+        import yaml
+
+        cfg = yaml.safe_load(_CONFIG.read_text()) or {}
+        if not isinstance(cfg, dict):
+            cfg, cfg_writable = {}, False
+    except FileNotFoundError:
+        pass  # fresh install — we create it
+    except Exception as e:
+        # Unparseable/unreadable: never risk clobbering the operator's file.
+        _log.warning("turn-taking: autoconfig cannot read %s (%s) — config part skipped", _CONFIG, e)
+        cfg_writable = False
+
+    config_updates, env_updates, notes, todos, sections = plan(cfg, _merged_env(), done)
+    if not sections:
+        return
+
+    if config_updates and cfg_writable:
+        try:
+            import yaml
+
+            cfg.update(config_updates)
+            _CONFIG.parent.mkdir(parents=True, exist_ok=True)
+            _CONFIG.write_text(yaml.safe_dump(cfg, sort_keys=False, allow_unicode=True))
+        except Exception as e:
+            _log.warning("turn-taking: autoconfig could not write %s: %s", _CONFIG, e)
+            notes = [n for n in notes if not n.startswith("core chat settings")]
+            sections = [s for s in sections if s != "core"]  # retry next boot
+    if env_updates:
+        try:
+            login.upsert_env(login.HERMES_ENV, env_updates)
+            os.environ.update(env_updates)  # keep this process consistent too
+        except Exception as e:
+            _log.warning("turn-taking: autoconfig could not write %s: %s", login.HERMES_ENV, e)
+
+    try:
+        _MARKER.parent.mkdir(parents=True, exist_ok=True)
+        _MARKER.write_text("\n".join(sorted(done | set(sections))) + "\n")
+    except Exception:
+        pass  # best-effort; worst case a section re-applies (it is idempotent)
+
+    for note in notes:
+        _log.warning("turn-taking: autoconfigured %s", note)
+    if not notes and not todos:
+        return
+
+    parts = []
+    if notes:
+        parts.append("🔧 Humalike plugin — configured hermes for turn-taking:\n"
+                     + "\n".join(f"   • {n}" for n in notes)
+                     + "\n   Restart hermes once to apply.")
+    parts.extend(todos)
+    report = "\n\n" + "\n\n".join(parts) + "\n"
+
+    def _announce() -> None:
+        login._wait_for_tui()
+        login._show(report)
+
+    threading.Thread(target=_announce, daemon=True, name="humalike-autoconfig").start()

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -250,11 +250,15 @@ def maybe_autoconfigure() -> None:
     lines = [f"   {'• ' if kind == 'fixed' else '✓ '}{label}"
              + (" — already right" if kind == "ok" else "")
              for kind, label in body]
-    if any_fixed:
-        lines.append("   Restart hermes once to apply.")
     parts = ["\n".join([header] + lines)] if body else []
     parts.extend(todos)
     parts.extend(f"⚠ {w}" for w in warns)
+    if any_fixed:
+        # Closing footer, last line of the whole report: the host reads these
+        # settings at startup, so a change made during THIS boot only takes
+        # effect on the next one — restart once more after the setup finishes.
+        parts.append("↻ Restart the hermes gateway once more after this setup to load the "
+                     "updated configuration.")
     report = "\n\n" + "\n\n".join(parts) + "\n"
 
     def _announce() -> None:

--- a/autoconfig.py
+++ b/autoconfig.py
@@ -200,8 +200,12 @@ def maybe_autoconfigure() -> None:
     if not sections:
         return
 
-    if config_updates and cfg_writable:
+    if config_updates:
         try:
+            if not cfg_writable:
+                # Unreadable/unparseable yaml: same recovery as a failed write —
+                # don't record 'done', don't claim 'fixed'; retry next boot.
+                raise RuntimeError("config.yaml unreadable — not overwriting")
             import yaml
 
             cfg.update(config_updates)

--- a/connect.py
+++ b/connect.py
@@ -1,0 +1,225 @@
+"""`/connect` — link this agent to a Humalike account (device authorization).
+
+The chat-first cousin of ``hermes setup``: the user sends ``/connect`` from any
+platform, gets back a login link, opens it in a browser on ANY device (their
+phone works — the gateway box never needs a display, so SSH/VM/Docker installs
+are first-class), approves, and the freshly minted API key is saved. The key
+goes live in-process immediately (``os.environ`` — every Humalike call reads it
+fresh via ``_config.api_key()``) and into ``~/.hermes/.env`` for the next boot,
+so no restart is needed.
+
+Server side is Humalike's RFC 8628 lane on the keys service:
+  POST {base}/v1/keys/actions/cli_create  -> {device_code, user_code,
+                                              verification_uri, expires_in, interval}
+  POST {base}/v1/keys/actions/cli_poll    {device_code} -> {status, api_key?, account?}
+
+``status`` is pending/authorized/denied/expired; on ``authorized`` the response
+carries the ``ak_…`` key exactly once (the server deletes the session as the
+claim). Any HTTP error while polling is transient by contract — keep polling;
+the session TTL, not this loop, is the real deadline.
+
+Command handlers only get ``raw_args`` and return one reply string, so the
+approval outcome is delivered later via the route captured at command time
+(``state.LAST_ADAPTER``/``LAST_CHAT_ID``, set by the inbound gate for the
+/connect message itself) — sent through the genuine pre-patch ``send`` so the
+draft-suppression patch can't swallow it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import platform
+import socket
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+import httpx
+
+from . import _config
+from .turn_taking import notify, state
+
+_log = logging.getLogger(__name__)
+
+_ENV_FILE = Path.home() / ".hermes" / ".env"
+_DEFAULT_API = "https://api.humalike.com"
+_CREATE = "/v1/keys/actions/cli_create"
+_POLL = "/v1/keys/actions/cli_poll"
+
+# RFC 8628 public client identifier for the CLI lane: it names the client (a
+# Hermes plugin install) to the API and unlocks ONLY cli_create/cli_poll — the
+# per-session device_code stays the sole credential that can claim a key, so
+# this ships in the open like any OAuth public client_id.
+# ponytail: no baked default yet — set HUMALIKE_CLI_GATEWAY_KEY until the
+# published identifier lands here in a follow-up.
+_GATEWAY_KEY_DEFAULT = ""
+
+_PENDING = threading.Event()  # one in-flight link at a time (cleared by _watch)
+
+
+def _api_url() -> str:
+    """Connect must work BEFORE install finishes, so unlike the turn-taking
+    service it falls back to the public API when HUMALIKE_API_URL is unset."""
+    return _config.service_url() or _DEFAULT_API
+
+
+def _gateway_key() -> str:
+    return os.getenv("HUMALIKE_CLI_GATEWAY_KEY") or _GATEWAY_KEY_DEFAULT
+
+
+def _headers() -> dict:
+    return {"Authorization": f"Bearer {_gateway_key()}", "Content-Type": "application/json"}
+
+
+# ── Command handler (registered as /connect) ──────────────────────────────────
+async def command(raw_args: str) -> str:
+    """Start a device-auth session and reply with the approval link."""
+    if _config.api_key():
+        return ("✅ Already connected — HUMALIKE_API_KEY is set. To relink, remove it from "
+                f"{_ENV_FILE}, restart the gateway, and send /connect again.")
+    if not _gateway_key():
+        return ("⚠️ /connect isn't configured on this install (no HUMALIKE_CLI_GATEWAY_KEY). "
+                "Create an API key at https://humalike.com and add it to "
+                f"{_ENV_FILE} as HUMALIKE_API_KEY=… instead.")
+    if _PENDING.is_set():
+        return "⏳ A connect link is already waiting to be approved — open it, or wait for it to expire and send /connect again."
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            r = await client.post(
+                _api_url() + _CREATE,
+                json={"client": "hermes", "hostname": socket.gethostname(), "os": platform.system()},
+                headers=_headers(),
+            )
+            r.raise_for_status()
+            session = r.json()
+    except Exception as e:
+        _log.warning("connect: cli_create failed: %s", e)
+        return "⚠️ Couldn't reach Humalike to start the link — check the gateway's network and send /connect again."
+
+    # The /connect message itself just went through the inbound gate, so this IS
+    # the invoking chat. A message racing in from another chat between the gate
+    # and this handler could mis-route the confirmation (rare; it carries no
+    # secret — worst case the wrong chat sees "Connected as <email>").
+    route = (state.LAST_ADAPTER, state.LAST_CHAT_ID)
+    _PENDING.set()
+    threading.Thread(target=_watch, args=(route, session), daemon=True, name="humalike-connect").start()
+
+    minutes = max(1, int(session.get("expires_in", 600)) // 60)
+    reply = ("🔗 Open this link on any device and approve to connect your Humalike account:\n\n"
+             f"{session['verification_uri']}\n\n"
+             f"I'll confirm here once you're done — the link is valid for ~{minutes} minutes. "
+             "(Anyone who opens it can link their own account, so prefer a DM in a busy group.)")
+    if not _config.service_url():
+        reply += ("\n\nHeads-up: HUMALIKE_API_URL isn't set, so after approving you still need to add "
+                  f"HUMALIKE_API_URL={_DEFAULT_API} to {_ENV_FILE} and restart the gateway.")
+    return reply
+
+
+# ── Background poll ────────────────────────────────────────────────────────────
+def _watch(route: Tuple[Any, str], session: dict) -> None:
+    """Poll until approved/denied/expired, then confirm in the /connect chat.
+
+    Own thread + own loop (soul's auto-enhance idiom) so neither the command
+    reply nor the gateway loop ever blocks on the ~10-minute approval window.
+    """
+    try:
+        message = asyncio.run(_poll(session))
+    except Exception as e:  # never let the watcher die silently
+        _log.warning("connect: poll loop errored: %s", e)
+        message = None
+    finally:
+        _PENDING.clear()
+    if message:
+        _deliver(route, message)
+
+
+async def _poll(session: dict) -> Optional[str]:
+    interval = max(1, int(session.get("interval", 3)))
+    deadline = time.monotonic() + int(session.get("expires_in", 600))
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        while time.monotonic() < deadline:
+            await asyncio.sleep(interval)
+            try:
+                r = await client.post(
+                    _api_url() + _POLL,
+                    json={"device_code": session["device_code"]},
+                    headers=_headers(),
+                )
+                r.raise_for_status()
+                data = r.json()
+            except Exception:
+                continue  # transient by contract — the session TTL is the deadline
+            status = data.get("status")
+            if status == "authorized":
+                _save_key(data.get("api_key") or "")
+                _log.info("connect: linked to Humalike account")
+                return _done_message(data)
+            if status in ("denied", "expired"):
+                return _result_message(status)
+            # pending (or an unknown future status) → keep polling until TTL
+    return _result_message("expired")
+
+
+def _result_message(status: str) -> str:
+    if status == "denied":
+        return "❌ The connect request was denied — send /connect to try again."
+    return "⌛ The connect link expired before it was approved — send /connect for a fresh one."
+
+
+def _done_message(data: dict) -> str:
+    who = (data.get("account") or {}).get("email") or "your account"
+    if _config.service_url():
+        return f"✅ Connected as {who} — key saved, turn-taking is active."
+    return (f"✅ Connected as {who} — key saved to {_ENV_FILE}. Now set HUMALIKE_API_URL there "
+            "and restart the gateway to activate turn-taking.")
+
+
+# ── Key persistence ────────────────────────────────────────────────────────────
+def _save_key(key: str) -> None:
+    """Live for THIS gateway (env — read fresh on every Humalike call, so
+    turn-taking activates with no restart) and durable for the next one."""
+    os.environ["HUMALIKE_API_KEY"] = key
+    try:
+        _write_env(_ENV_FILE, key)
+    except Exception as e:
+        _log.warning("connect: could not write %s (%s) — key active until restart only", _ENV_FILE, e)
+
+
+def _write_env(path: Path, key: str) -> None:
+    """Upsert ``HUMALIKE_API_KEY=…``, preserving every other line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = path.read_text().splitlines() if path.exists() else []
+    lines = [ln for ln in lines if not ln.startswith("HUMALIKE_API_KEY=")]
+    lines.append(f"HUMALIKE_API_KEY={key}")
+    path.write_text("\n".join(lines) + "\n")
+    try:
+        path.chmod(0o600)  # it now holds a live credential
+    except Exception:
+        pass
+
+
+# ── Outcome delivery ───────────────────────────────────────────────────────────
+def _deliver(route: Tuple[Any, str], text: str) -> None:
+    """Send the outcome to the chat /connect came from, via the genuine
+    pre-patch ``send`` (notify's idiom) so the draft-suppression patch can't
+    swallow it. No route (e.g. a platform whose commands bypass our inbound
+    gate) → the home-channel startup queue as a best-effort fallback."""
+    adapter, chat_id = route
+    if adapter is None or not chat_id:
+        notify.queue_startup(text)
+        return
+
+    async def _send() -> None:
+        try:
+            orig = state.ORIG_SEND.get(type(adapter))
+            if orig is not None:
+                await orig(adapter, str(chat_id), text)
+            else:
+                await adapter.send(str(chat_id), text)
+        except Exception as e:
+            _log.warning("connect: confirmation send failed: %s", e)
+
+    notify._schedule(_send)

--- a/connect.py
+++ b/connect.py
@@ -77,6 +77,13 @@ def _headers() -> dict:
 # ── Command handler (registered as /connect) ──────────────────────────────────
 async def command(raw_args: str) -> str:
     """Start a device-auth session and reply with the approval link."""
+    # Capture the invoking chat FIRST, before any await: the /connect message
+    # itself just went through the inbound gate, so the pair still names this
+    # chat. Awaiting first would let any other chat's inbound overwrite the
+    # globals during the HTTP round-trip and mis-route the confirmation. A
+    # residual race (another chat between the gate and this handler) remains;
+    # it carries no secret — worst case the wrong chat sees "Connected as <email>".
+    route = (state.LAST_ADAPTER, state.LAST_CHAT_ID)
     if _config.api_key():
         return ("✅ Already connected — HUMALIKE_API_KEY is set. To relink, remove it from "
                 f"{_ENV_FILE}, restart the gateway, and send /connect again.")
@@ -86,6 +93,9 @@ async def command(raw_args: str) -> str:
                 f"{_ENV_FILE} as HUMALIKE_API_KEY=… instead.")
     if _PENDING.is_set():
         return "⏳ A connect link is already waiting to be approved — open it, or wait for it to expire and send /connect again."
+    # No await between the is_set() check and set() (single-threaded loop), so
+    # two concurrent /connect can't both pass. Cleared by _watch, or below on failure.
+    _PENDING.set()
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
             r = await client.post(
@@ -95,22 +105,30 @@ async def command(raw_args: str) -> str:
             )
             r.raise_for_status()
             session = r.json()
+        threading.Thread(target=_watch, args=(route, session), daemon=True, name="humalike-connect").start()
     except Exception as e:
+        _PENDING.clear()
+        status = getattr(getattr(e, "response", None), "status_code", None)
+        if status is not None:
+            _log.warning("connect: cli_create → HTTP %s: %s", status, getattr(e.response, "text", "")[:200])
+            return (f"⚠️ Humalike rejected the connect request (HTTP {status}) — "
+                    "check HUMALIKE_CLI_GATEWAY_KEY, then send /connect again.")
         _log.warning("connect: cli_create failed: %s", e)
         return "⚠️ Couldn't reach Humalike to start the link — check the gateway's network and send /connect again."
 
-    # The /connect message itself just went through the inbound gate, so this IS
-    # the invoking chat. A message racing in from another chat between the gate
-    # and this handler could mis-route the confirmation (rare; it carries no
-    # secret — worst case the wrong chat sees "Connected as <email>").
-    route = (state.LAST_ADAPTER, state.LAST_CHAT_ID)
-    _PENDING.set()
-    threading.Thread(target=_watch, args=(route, session), daemon=True, name="humalike-connect").start()
-
     minutes = max(1, int(session.get("expires_in", 600)) // 60)
+    if route[0] is not None and route[1]:
+        tail = f"I'll confirm here once you're done — the link is valid for ~{minutes} minutes."
+    else:
+        # No deliverable route (URL unset → no patches, or a platform whose
+        # commands bypass our inbound gate): don't promise a confirmation we
+        # can't send — the outcome lands in the gateway log instead.
+        tail = (f"The link is valid for ~{minutes} minutes. I can't post a confirmation in this chat, "
+                f"so after approving, check that HUMALIKE_API_KEY appeared in {_ENV_FILE} "
+                "(the outcome is also in the gateway log).")
     reply = ("🔗 Open this link on any device and approve to connect your Humalike account:\n\n"
              f"{session['verification_uri']}\n\n"
-             f"I'll confirm here once you're done — the link is valid for ~{minutes} minutes. "
+             f"{tail} "
              "(Anyone who opens it can link their own account, so prefer a DM in a busy group.)")
     if not _config.service_url():
         reply += ("\n\nHeads-up: HUMALIKE_API_URL isn't set, so after approving you still need to add "
@@ -133,6 +151,7 @@ def _watch(route: Tuple[Any, str], session: dict) -> None:
     finally:
         _PENDING.clear()
     if message:
+        _log.info("connect: %s", message)  # headless installs read the outcome here
         _deliver(route, message)
 
 
@@ -155,7 +174,6 @@ async def _poll(session: dict) -> Optional[str]:
             status = data.get("status")
             if status == "authorized":
                 _save_key(data.get("api_key") or "")
-                _log.info("connect: linked to Humalike account")
                 return _done_message(data)
             if status in ("denied", "expired"):
                 return _result_message(status)
@@ -189,14 +207,17 @@ def _save_key(key: str) -> None:
 
 
 def _write_env(path: Path, key: str) -> None:
-    """Upsert ``HUMALIKE_API_KEY=…``, preserving every other line."""
+    """Upsert ``HUMALIKE_API_KEY=…``, preserving every other line. A fresh file
+    is created 0600 from the first byte (no world-readable window)."""
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = path.read_text().splitlines() if path.exists() else []
     lines = [ln for ln in lines if not ln.startswith("HUMALIKE_API_KEY=")]
     lines.append(f"HUMALIKE_API_KEY={key}")
-    path.write_text("\n".join(lines) + "\n")
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        fh.write("\n".join(lines) + "\n")
     try:
-        path.chmod(0o600)  # it now holds a live credential
+        path.chmod(0o600)  # a pre-existing file keeps its old mode otherwise
     except Exception:
         pass
 
@@ -206,7 +227,11 @@ def _deliver(route: Tuple[Any, str], text: str) -> None:
     """Send the outcome to the chat /connect came from, via the genuine
     pre-patch ``send`` (notify's idiom) so the draft-suppression patch can't
     swallow it. No route (e.g. a platform whose commands bypass our inbound
-    gate) → the home-channel startup queue as a best-effort fallback."""
+    gate) → the home-channel startup queue as a best-effort fallback — that
+    queue only flushes while the patches are active, which is why command()
+    stops promising an in-chat confirmation when the route is empty.
+    ponytail: sent without platform metadata, so on a Telegram forum-group the
+    confirmation lands in the General topic, not the invoking one."""
     adapter, chat_id = route
     if adapter is None or not chat_id:
         notify.queue_startup(text)

--- a/connect.py
+++ b/connect.py
@@ -121,8 +121,8 @@ async def command(raw_args: str) -> str:
              f"{tail} "
              "(Anyone who opens it can link their own account, so prefer a DM in a busy group.)")
     if not _config.service_url():
-        reply += ("\n\nHeads-up: HUMALIKE_API_URL isn't set, so after approving you still need to add "
-                  f"HUMALIKE_API_URL={_DEFAULT_API} to {_ENV_FILE} and restart the gateway.")
+        reply += ("\n\nHeads-up: turn-taking is explicitly disabled (HUMALIKE_API_URL is set empty) — "
+                  "remove that override and restart the gateway to activate it after approving.")
     return reply
 
 
@@ -159,8 +159,8 @@ def _done_message(data: dict) -> str:
     who = (data.get("account") or {}).get("email") or "your account"
     if _config.service_url():
         return f"✅ Connected as {who} — key saved, turn-taking is active."
-    return (f"✅ Connected as {who} — key saved to {_ENV_FILE}. Now set HUMALIKE_API_URL there "
-            "and restart the gateway to activate turn-taking.")
+    return (f"✅ Connected as {who} — key saved to {_ENV_FILE}. Turn-taking stays disabled while "
+            "HUMALIKE_API_URL is set empty — remove that override and restart to activate it.")
 
 
 # ── Key persistence ────────────────────────────────────────────────────────────

--- a/connect.py
+++ b/connect.py
@@ -77,12 +77,18 @@ async def command(raw_args: str) -> str:
     if _config.api_key():
         return ("✅ Already connected — HUMALIKE_API_KEY is set. To relink, remove it from "
                 f"{_ENV_FILE}, restart the gateway, and send /connect again.")
+    # A login may already be in flight — /connect's own, or the first-boot
+    # popup (whose print a TUI banner can hide): RE-SHOW that link instead of
+    # minting a competing session.
+    pending = login.PENDING_URI
+    if _PENDING.is_set() or pending:
+        if pending:
+            return f"⏳ A connect link is already waiting — approve it here:\n\n{pending}"
+        return "⏳ A connect link is already waiting to be approved — open it, or wait for it to expire and send /connect again."
     if not _gateway_key():
         return ("⚠️ /connect isn't configured on this install (no HUMALIKE_CLI_GATEWAY_KEY). "
                 "Create an API key at https://humalike.com and add it to "
                 f"{_ENV_FILE} as HUMALIKE_API_KEY=… instead.")
-    if _PENDING.is_set():
-        return "⏳ A connect link is already waiting to be approved — open it, or wait for it to expire and send /connect again."
     # No await between the is_set() check and set() (single-threaded loop), so
     # two concurrent /connect can't both pass. Cleared by _watch, or below on failure.
     _PENDING.set()
@@ -95,6 +101,7 @@ async def command(raw_args: str) -> str:
             )
             r.raise_for_status()
             session = r.json()
+        login.PENDING_URI = session["verification_uri"]  # /connect re-shows it while pending
         threading.Thread(target=_watch, args=(route, session), daemon=True, name="humalike-connect").start()
     except Exception as e:
         _PENDING.clear()
@@ -144,6 +151,7 @@ def _watch(route: Tuple[Any, str], session: dict) -> None:
         _log.warning("connect: poll loop errored: %s", e)
     finally:
         _PENDING.clear()
+        login.PENDING_URI = None
     if message:
         _log.info("connect: %s", message)  # headless installs read the outcome here
         _deliver(route, message)

--- a/connect.py
+++ b/connect.py
@@ -27,35 +27,25 @@ draft-suppression patch can't swallow it.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import platform
 import socket
 import threading
-import time
-from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Any, Tuple
 
 import httpx
 
-from . import _config
+from . import _config, login
 from .turn_taking import notify, state
 
 _log = logging.getLogger(__name__)
 
-_ENV_FILE = Path.home() / ".hermes" / ".env"
-_DEFAULT_API = "https://api.humalike.com"
-_CREATE = "/v1/keys/actions/cli_create"
-_POLL = "/v1/keys/actions/cli_poll"
-
-# RFC 8628 public client identifier for the CLI lane: it names the client (a
-# Hermes plugin install) to the API and unlocks ONLY cli_create/cli_poll — the
-# per-session device_code stays the sole credential that can claim a key, so
-# this ships in the open like any OAuth public client_id.
-# ponytail: no baked default yet — set HUMALIKE_CLI_GATEWAY_KEY until the
-# published identifier lands here in a follow-up.
-_GATEWAY_KEY_DEFAULT = ""
+# Shared with login.py (the terminal/install-time flow): API paths, the .env
+# location, and the public client identifier all live there.
+_ENV_FILE = login.HERMES_ENV
+_DEFAULT_API = login.DEFAULT_API
+_CREATE = login.CREATE
 
 _PENDING = threading.Event()  # one in-flight link at a time (cleared by _watch)
 
@@ -67,7 +57,7 @@ def _api_url() -> str:
 
 
 def _gateway_key() -> str:
-    return os.getenv("HUMALIKE_CLI_GATEWAY_KEY") or _GATEWAY_KEY_DEFAULT
+    return login.gateway_key()  # env first, then ~/.hermes/.env (the installer writes it there)
 
 
 def _headers() -> dict:
@@ -138,47 +128,25 @@ async def command(raw_args: str) -> str:
 
 # ── Background poll ────────────────────────────────────────────────────────────
 def _watch(route: Tuple[Any, str], session: dict) -> None:
-    """Poll until approved/denied/expired, then confirm in the /connect chat.
-
-    Own thread + own loop (soul's auto-enhance idiom) so neither the command
-    reply nor the gateway loop ever blocks on the ~10-minute approval window.
-    """
+    """Poll until approved/denied/expired (login.poll_session — sync stdlib,
+    fine on this daemon thread), then confirm in the /connect chat. Neither the
+    command reply nor the gateway loop ever blocks on the ~10-minute window."""
+    message = None
     try:
-        message = asyncio.run(_poll(session))
+        data = login.poll_session(session, _gateway_key())
+        status = data.get("status")
+        if status == "authorized":
+            _save_key(data.get("api_key") or "")
+            message = _done_message(data)
+        else:
+            message = _result_message(status)
     except Exception as e:  # never let the watcher die silently
         _log.warning("connect: poll loop errored: %s", e)
-        message = None
     finally:
         _PENDING.clear()
     if message:
         _log.info("connect: %s", message)  # headless installs read the outcome here
         _deliver(route, message)
-
-
-async def _poll(session: dict) -> Optional[str]:
-    interval = max(1, int(session.get("interval", 3)))
-    deadline = time.monotonic() + int(session.get("expires_in", 600))
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        while time.monotonic() < deadline:
-            await asyncio.sleep(interval)
-            try:
-                r = await client.post(
-                    _api_url() + _POLL,
-                    json={"device_code": session["device_code"]},
-                    headers=_headers(),
-                )
-                r.raise_for_status()
-                data = r.json()
-            except Exception:
-                continue  # transient by contract — the session TTL is the deadline
-            status = data.get("status")
-            if status == "authorized":
-                _save_key(data.get("api_key") or "")
-                return _done_message(data)
-            if status in ("denied", "expired"):
-                return _result_message(status)
-            # pending (or an unknown future status) → keep polling until TTL
-    return _result_message("expired")
 
 
 def _result_message(status: str) -> str:
@@ -201,25 +169,9 @@ def _save_key(key: str) -> None:
     turn-taking activates with no restart) and durable for the next one."""
     os.environ["HUMALIKE_API_KEY"] = key
     try:
-        _write_env(_ENV_FILE, key)
+        login.write_env_key(_ENV_FILE, key)
     except Exception as e:
         _log.warning("connect: could not write %s (%s) — key active until restart only", _ENV_FILE, e)
-
-
-def _write_env(path: Path, key: str) -> None:
-    """Upsert ``HUMALIKE_API_KEY=…``, preserving every other line. A fresh file
-    is created 0600 from the first byte (no world-readable window)."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lines = path.read_text().splitlines() if path.exists() else []
-    lines = [ln for ln in lines if not ln.startswith("HUMALIKE_API_KEY=")]
-    lines.append(f"HUMALIKE_API_KEY={key}")
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as fh:
-        fh.write("\n".join(lines) + "\n")
-    try:
-        path.chmod(0o600)  # a pre-existing file keeps its old mode otherwise
-    except Exception:
-        pass
 
 
 # ── Outcome delivery ───────────────────────────────────────────────────────────

--- a/login.py
+++ b/login.py
@@ -125,13 +125,14 @@ def _wait_for_tui(timeout: float = 8.0) -> None:
 
 
 # ── Key persistence ───────────────────────────────────────────────────────────
-def write_env_key(path: Path, key: str) -> None:
-    """Upsert ``HUMALIKE_API_KEY=…``, preserving every other line. A fresh file
-    is created 0600 from the first byte (no world-readable window)."""
+def upsert_env(path: Path, updates: dict) -> None:
+    """Upsert ``KEY=VALUE`` lines, preserving every other line (comments
+    included). A fresh file is created 0600 from the first byte (no
+    world-readable window — it can hold a live credential)."""
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = path.read_text().splitlines() if path.exists() else []
-    lines = [ln for ln in lines if not ln.startswith("HUMALIKE_API_KEY=")]
-    lines.append(f"HUMALIKE_API_KEY={key}")
+    lines = [ln for ln in lines if ln.split("=", 1)[0].strip() not in updates]
+    lines += [f"{k}={v}" for k, v in updates.items()]
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w") as fh:
         fh.write("\n".join(lines) + "\n")
@@ -139,6 +140,11 @@ def write_env_key(path: Path, key: str) -> None:
         path.chmod(0o600)  # a pre-existing file keeps its old mode otherwise
     except Exception:
         pass
+
+
+def write_env_key(path: Path, key: str) -> None:
+    """Upsert the API key (see :func:`upsert_env`)."""
+    upsert_env(path, {"HUMALIKE_API_KEY": key})
 
 
 # ── The device-auth API (sync, stdlib) ────────────────────────────────────────

--- a/login.py
+++ b/login.py
@@ -12,8 +12,8 @@ is approved, then writes HUMALIKE_API_KEY into ``~/.hermes/.env``.
 
 Three callers share this module:
   * the terminal (``__main__``) — install-time login,
-  * ``register()`` via :func:`maybe_first_boot_login` — pops the login once on
-    the first keyless gateway boot (marker-guarded),
+  * ``register()`` via :func:`maybe_first_boot_login` — pops the login on every
+    boot that has no working API key (see :func:`has_working_key`),
   * ``connect.py`` — reuses :func:`poll_session` and :func:`write_env_key`.
 
 Config is read from the process environment first, then ``~/.hermes/.env`` —
@@ -30,6 +30,7 @@ import socket
 import sys
 import threading
 import time
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -51,6 +52,11 @@ HERMES_ENV = _hermes_home() / ".env"
 DEFAULT_API = "https://api.humalike.com"
 CREATE = "/v1/keys/actions/cli_create"
 POLL = "/v1/keys/actions/cli_poll"
+# Key-validation probe: authed by the USER key (Bearer HUMALIKE_API_KEY), 200 =
+# works, 401/403 = dead. None until the svc-keys endpoint lands — while None,
+# a present key counts as working (no network call, no needless re-login).
+# TODO: set to the whoami/validate path once it exists (see the server ticket).
+WHOAMI_PATH: str | None = None
 
 # RFC 8628 public client identifier for the CLI lane: it names the client (a
 # Hermes plugin install) to the API and unlocks ONLY cli_create/cli_poll — the
@@ -58,8 +64,6 @@ POLL = "/v1/keys/actions/cli_poll"
 # this ships in the open like any OAuth public client_id. Override with
 # HUMALIKE_CLI_GATEWAY_KEY (e.g. for staging).
 GATEWAY_KEY_DEFAULT = "hcg_360rQLmr4iabWKiEqc5ZFXY5sUM8g-wTjFO3cwNgTlI"
-
-_MARKER = _hermes_home() / ".turn_taking_login_prompted"
 
 # The not-yet-approved link, while a login (first-boot or /connect) is in
 # flight — None when idle. Lets /connect RE-SHOW the pending link instead of
@@ -145,18 +149,52 @@ def upsert_env(path: Path, updates: dict) -> None:
     lines = path.read_text().splitlines() if path.exists() else []
     lines = [ln for ln in lines if ln.split("=", 1)[0].strip() not in updates]
     lines += [f"{k}={v}" for k, v in updates.items()]
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    # Atomic swap: write a private temp then os.replace onto the real path, so a
+    # crash or a second process writing concurrently can never truncate .env and
+    # lose the platform tokens. Temp is pid-unique so two writers don't clobber
+    # each other's temp; os.replace is atomic, last writer wins cleanly.
+    tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w") as fh:
         fh.write("\n".join(lines) + "\n")
-    try:
-        path.chmod(0o600)  # a pre-existing file keeps its old mode otherwise
-    except Exception:
-        pass
+    os.replace(tmp, path)
 
 
 def write_env_key(path: Path, key: str) -> None:
     """Upsert the API key (see :func:`upsert_env`)."""
     upsert_env(path, {"HUMALIKE_API_KEY": key})
+
+
+# ── Key validation ────────────────────────────────────────────────────────────
+_key_ok: bool | None = None  # per-process cache: probe whoami at most once a boot
+
+
+def _probe(key: str) -> bool:
+    """Ask the API whether ``key`` is live. True on 2xx; True on ANY network or
+    server error (an outage must not force a needless re-login); False ONLY on
+    an explicit 401/403 rejection."""
+    try:
+        req = urllib.request.Request(
+            api_url() + WHOAMI_PATH, data=b"{}",
+            headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=5):  # noqa: S310 — our own API URL
+            return True
+    except urllib.error.HTTPError as e:
+        return e.code not in (401, 403)
+    except Exception:
+        return True
+
+
+def has_working_key() -> bool:
+    """True when a usable API key is configured (cached per process). No key →
+    False. Key present → validated via ``WHOAMI_PATH`` when set; until that
+    endpoint exists, presence alone counts as working (no probe, no re-login)."""
+    global _key_ok
+    if _key_ok is None:
+        key = cfg("HUMALIKE_API_KEY")
+        _key_ok = bool(key) and (True if not WHOAMI_PATH else _probe(key))
+    return _key_ok
 
 
 # ── The device-auth API (sync, stdlib) ────────────────────────────────────────
@@ -207,8 +245,8 @@ def run(wait_for_tui: bool = False) -> int:
     ``wait_for_tui`` (the first-boot path inside hermes): delay the first
     link display until the TUI is up, so the link lands BELOW the banner —
     a pre-banner print just scrolls out of sight."""
-    if cfg("HUMALIKE_API_KEY"):
-        print("Already connected — HUMALIKE_API_KEY is set.")
+    if has_working_key():
+        print("Already connected — HUMALIKE_API_KEY is set and valid.")
         return 0
     bearer = gateway_key()
     if not bearer:
@@ -227,6 +265,11 @@ def run(wait_for_tui: bool = False) -> int:
     # only THEN display — after the TUI is up when asked, so the link prints
     # below the banner via run_in_terminal instead of scrolling away above it.
     _log.warning("humalike login: approve at %s (valid ~%d min)", uri, minutes)
+    # Plain stdout too, flushed: the TUI-safe _show routes through the prompt
+    # app's terminal, which `docker compose logs` (stdout) never sees — this
+    # line is the one a headless/containerized operator can actually read.
+    print(f"[Humalike] Connect your account — approve at: {uri}  (valid ~{minutes} min)",
+          flush=True)
     try:
         import webbrowser
 
@@ -260,6 +303,8 @@ def run(wait_for_tui: bool = False) -> int:
         key = data.get("api_key") or ""
         write_env_key(HERMES_ENV, key)
         os.environ["HUMALIKE_API_KEY"] = key  # live for this process too
+        global _key_ok
+        _key_ok = True  # freshly minted key is valid — don't re-probe this boot
         who = (data.get("account") or {}).get("email") or "your account"
         _log.warning("humalike login: connected as %s", who)
         _show(f"\n✅ Connected as {who} — key saved to {HERMES_ENV}.\n")
@@ -271,26 +316,19 @@ def run(wait_for_tui: bool = False) -> int:
 
 # ── First-boot popup (called from register()) ─────────────────────────────────
 def maybe_first_boot_login() -> None:
-    """Pop the login once, on the first keyless gateway boot: a browser tab on
-    a desktop, the printed URL on the gateway console otherwise. Runs on a
-    daemon thread so boot never blocks on the ~10-minute approval window.
-
-    Marker written when the prompt FIRES, not on success — an ignored tab must
-    not reopen on every boot. Retry paths: delete the marker, rerun login.py,
-    or send /connect."""
-    if cfg("HUMALIKE_API_KEY"):
-        return  # already connected
+    """(Re)run the device login whenever there is no WORKING API key — every
+    boot until connected. No marker: the source of truth is the key itself
+    (:func:`has_working_key`), not an 'already asked' flag, so a login the
+    operator couldn't see (headless) or that a restart interrupted simply
+    re-offers next boot instead of being lost forever. Runs on a daemon thread
+    so boot never blocks on the ~10-minute approval window. Concurrent boots
+    (gateway + dashboard) may each pop a link; the unapproved one just expires
+    and the .env write is atomic, so nothing is corrupted or wedged."""
     if not gateway_key():
         _log.info("humalike login: skipped — no client identifier configured")
         return
-    if _MARKER.exists():
-        _log.info("humalike login: already prompted once (delete %s to retry, or send /connect)", _MARKER)
-        return
-    try:
-        _MARKER.parent.mkdir(parents=True, exist_ok=True)
-        _MARKER.write_text("1")
-    except OSError:
-        pass  # best-effort; worst case the prompt repeats next boot
+    if has_working_key():
+        return  # connected and valid — nothing to do
     threading.Thread(target=lambda: run(wait_for_tui=True), daemon=True, name="humalike-login").start()
 
 

--- a/login.py
+++ b/login.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Terminal device-authorization login — the install-time cousin of /connect.
+
+Run it right after installing the plugin (stdlib only — no Hermes venv, no
+httpx):
+
+    python3 ~/.hermes/plugins/turn-taking/login.py
+
+Prints the approval URL (and opens a browser tab when the machine has one — on
+SSH/headless boxes open the printed link on your phone), polls until the link
+is approved, then writes HUMALIKE_API_KEY into ``~/.hermes/.env``.
+
+Three callers share this module:
+  * the terminal (``__main__``) — install-time login,
+  * ``register()`` via :func:`maybe_first_boot_login` — pops the login once on
+    the first keyless gateway boot (marker-guarded),
+  * ``connect.py`` — reuses :func:`poll_session` and :func:`write_env_key`.
+
+Config is read from the process environment first, then ``~/.hermes/.env`` —
+the installer writes the gateway key to the file before any shell exports it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import socket
+import sys
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+HERMES_ENV = Path.home() / ".hermes" / ".env"
+DEFAULT_API = "https://api.humalike.com"
+CREATE = "/v1/keys/actions/cli_create"
+POLL = "/v1/keys/actions/cli_poll"
+
+# RFC 8628 public client identifier for the CLI lane: it names the client (a
+# Hermes plugin install) to the API and unlocks ONLY cli_create/cli_poll — the
+# per-session device_code stays the sole credential that can claim a key, so
+# this ships in the open like any OAuth public client_id.
+# ponytail: no baked default yet — set HUMALIKE_CLI_GATEWAY_KEY until the
+# published identifier lands here in a follow-up.
+GATEWAY_KEY_DEFAULT = ""
+
+_MARKER = Path.home() / ".hermes" / ".turn_taking_login_prompted"
+
+
+# ── Config (env first, then ~/.hermes/.env) ───────────────────────────────────
+def read_env_file(path: Path | None = None) -> dict:
+    """``KEY=VALUE`` lines (just the subset we need — no quoting/expansion)."""
+    try:
+        lines = (path or HERMES_ENV).read_text().splitlines()
+    except OSError:
+        return {}
+    out = {}
+    for ln in lines:
+        ln = ln.strip()
+        if ln and not ln.startswith("#") and "=" in ln:
+            k, _, v = ln.partition("=")
+            out[k.strip()] = v.strip()
+    return out
+
+
+def cfg(name: str, default: str = "") -> str:
+    return os.getenv(name) or read_env_file().get(name, "") or default
+
+
+def gateway_key() -> str:
+    return cfg("HUMALIKE_CLI_GATEWAY_KEY", GATEWAY_KEY_DEFAULT)
+
+
+def api_url() -> str:
+    return cfg("HUMALIKE_API_URL", DEFAULT_API).rstrip("/")
+
+
+# ── Key persistence ───────────────────────────────────────────────────────────
+def write_env_key(path: Path, key: str) -> None:
+    """Upsert ``HUMALIKE_API_KEY=…``, preserving every other line. A fresh file
+    is created 0600 from the first byte (no world-readable window)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = path.read_text().splitlines() if path.exists() else []
+    lines = [ln for ln in lines if not ln.startswith("HUMALIKE_API_KEY=")]
+    lines.append(f"HUMALIKE_API_KEY={key}")
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+    try:
+        path.chmod(0o600)  # a pre-existing file keeps its old mode otherwise
+    except Exception:
+        pass
+
+
+# ── The device-auth API (sync, stdlib) ────────────────────────────────────────
+def post(path: str, body: dict, bearer: str) -> dict:
+    req = urllib.request.Request(
+        api_url() + path,
+        data=json.dumps(body).encode(),
+        headers={"Authorization": f"Bearer {bearer}", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=15) as r:  # noqa: S310 — our own API URL
+        return json.load(r)
+
+
+def create_session(bearer: str) -> dict:
+    return post(CREATE, {"client": "hermes", "hostname": socket.gethostname(),
+                         "os": platform.system()}, bearer)
+
+
+def poll_session(session: dict, bearer: str) -> dict:
+    """Blocking poll until a terminal status; returns the final poll body
+    (``{'status': 'expired'}`` synthesized on TTL). Any HTTP error is transient
+    by contract — keep polling; the session TTL is the real deadline. Unknown
+    future statuses are treated as pending."""
+    interval = max(1, int(session.get("interval", 3)))
+    deadline = time.monotonic() + int(session.get("expires_in", 600))
+    while time.monotonic() < deadline:
+        time.sleep(interval)
+        try:
+            data = post(POLL, {"device_code": session["device_code"]}, bearer)
+        except Exception:
+            continue
+        if data.get("status") in ("authorized", "denied", "expired"):
+            return data
+    return {"status": "expired"}
+
+
+# ── Terminal flow ─────────────────────────────────────────────────────────────
+def run() -> int:
+    """0 = key saved (or already present), 1 = failed/denied/expired."""
+    if cfg("HUMALIKE_API_KEY"):
+        print("Already connected — HUMALIKE_API_KEY is set.")
+        return 0
+    bearer = gateway_key()
+    if not bearer:
+        print("No HUMALIKE_CLI_GATEWAY_KEY configured — create an API key at "
+              f"https://humalike.com and put HUMALIKE_API_KEY=… in {HERMES_ENV} instead.")
+        return 1
+    try:
+        session = create_session(bearer)
+    except Exception as e:
+        print(f"Could not reach Humalike to start the login ({e}).")
+        return 1
+
+    uri = session["verification_uri"]
+    minutes = max(1, int(session.get("expires_in", 600)) // 60)
+    print("\nOpen this link on any device and approve to connect your Humalike account:\n"
+          f"\n    {uri}\n"
+          f"\nWaiting for approval (link valid ~{minutes} min, Ctrl-C to abort)…")
+    try:
+        import webbrowser
+
+        webbrowser.open(uri)  # pops a tab on a desktop; harmless no-op headless
+    except Exception:
+        pass
+
+    data = poll_session(session, bearer)
+    status = data.get("status")
+    if status == "authorized":
+        key = data.get("api_key") or ""
+        write_env_key(HERMES_ENV, key)
+        os.environ["HUMALIKE_API_KEY"] = key  # live for this process too
+        who = (data.get("account") or {}).get("email") or "your account"
+        print(f"✅ Connected as {who} — key saved to {HERMES_ENV}.")
+        return 0
+    print(f"Login {status} — run this script again (or send the bot /connect) to retry.")
+    return 1
+
+
+# ── First-boot popup (called from register()) ─────────────────────────────────
+def maybe_first_boot_login() -> None:
+    """Pop the login once, on the first keyless gateway boot: a browser tab on
+    a desktop, the printed URL on the gateway console otherwise. Runs on a
+    daemon thread so boot never blocks on the ~10-minute approval window.
+
+    Marker written when the prompt FIRES, not on success — an ignored tab must
+    not reopen on every boot. Retry paths: delete the marker, rerun login.py,
+    or send /connect."""
+    if cfg("HUMALIKE_API_KEY") or not gateway_key() or _MARKER.exists():
+        return
+    try:
+        _MARKER.parent.mkdir(parents=True, exist_ok=True)
+        _MARKER.write_text("1")
+    except OSError:
+        pass  # best-effort; worst case the prompt repeats next boot
+    threading.Thread(target=run, daemon=True, name="humalike-login").start()
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/login.py
+++ b/login.py
@@ -1,17 +1,10 @@
-#!/usr/bin/env python3
-"""Terminal device-authorization login — the install-time cousin of /connect.
-
-Run it right after installing the plugin (stdlib only — no Hermes venv, no
-httpx):
-
-    python3 ~/.hermes/plugins/humalike/login.py
+"""Device-authorization login (stdlib only, no httpx).
 
 Prints the approval URL (and opens a browser tab when the machine has one — on
 SSH/headless boxes open the printed link on your phone), polls until the link
 is approved, then writes HUMALIKE_API_KEY into ``~/.hermes/.env``.
 
-Three callers share this module:
-  * the terminal (``__main__``) — install-time login,
+Two callers share this module (it is not a standalone script):
   * ``register()`` via :func:`maybe_first_boot_login` — pops the login once on
     the first keyless gateway boot (marker-guarded),
   * ``connect.py`` — reuses :func:`poll_session` and :func:`write_env_key`.
@@ -27,7 +20,6 @@ import logging
 import os
 import platform
 import socket
-import sys
 import threading
 import time
 import urllib.request
@@ -44,6 +36,7 @@ def _hermes_home() -> Path:
 
         return Path(get_hermes_home())
     except Exception:
+        # hermes_constants not importable (e.g. imported outside the gateway venv)
         return Path(os.getenv("HERMES_HOME") or "~/.hermes").expanduser()
 
 
@@ -200,7 +193,7 @@ def poll_session(session: dict, bearer: str, on_wait=None) -> dict:
     return {"status": "expired"}
 
 
-# ── Terminal flow ─────────────────────────────────────────────────────────────
+# ── Login flow (internal; run on a daemon thread by maybe_first_boot_login) ───
 def run(wait_for_tui: bool = False) -> int:
     """0 = key saved (or already present), 1 = failed/denied/expired.
 
@@ -265,7 +258,7 @@ def run(wait_for_tui: bool = False) -> int:
         _show(f"\n✅ Connected as {who} — key saved to {HERMES_ENV}.\n")
         return 0
     _log.warning("humalike login: %s", status)
-    _show(f"\nLogin {status} — send the bot /connect (or rerun login.py) to retry.\n")
+    _show(f"\nLogin {status} — send the bot /connect to retry.\n")
     return 1
 
 
@@ -276,8 +269,8 @@ def maybe_first_boot_login() -> None:
     daemon thread so boot never blocks on the ~10-minute approval window.
 
     Marker written when the prompt FIRES, not on success — an ignored tab must
-    not reopen on every boot. Retry paths: delete the marker, rerun login.py,
-    or send /connect."""
+    not reopen on every boot. Retry paths: delete the marker and restart, or
+    send /connect."""
     if cfg("HUMALIKE_API_KEY"):
         return  # already connected
     if not gateway_key():
@@ -292,7 +285,3 @@ def maybe_first_boot_login() -> None:
     except OSError:
         pass  # best-effort; worst case the prompt repeats next boot
     threading.Thread(target=lambda: run(wait_for_tui=True), daemon=True, name="humalike-login").start()
-
-
-if __name__ == "__main__":
-    sys.exit(run())

--- a/login.py
+++ b/login.py
@@ -30,7 +30,7 @@ _log = logging.getLogger(__name__)
 def _hermes_home() -> Path:
     """The real hermes home: the host's single source of truth when importable
     (HERMES_HOME-aware, platform-native defaults), else the env var, else
-    ``~/.hermes`` (login.py run standalone outside the hermes venv)."""
+    ``~/.hermes`` (when hermes_constants isn't importable)."""
     try:
         from hermes_constants import get_hermes_home  # noqa: PLC0415
 

--- a/login.py
+++ b/login.py
@@ -23,6 +23,7 @@ the installer writes the gateway key to the file before any shell exports it.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import platform
 import socket
@@ -32,6 +33,8 @@ import time
 import urllib.request
 from pathlib import Path
 
+_log = logging.getLogger(__name__)
+
 HERMES_ENV = Path.home() / ".hermes" / ".env"
 DEFAULT_API = "https://api.humalike.com"
 CREATE = "/v1/keys/actions/cli_create"
@@ -40,10 +43,9 @@ POLL = "/v1/keys/actions/cli_poll"
 # RFC 8628 public client identifier for the CLI lane: it names the client (a
 # Hermes plugin install) to the API and unlocks ONLY cli_create/cli_poll — the
 # per-session device_code stays the sole credential that can claim a key, so
-# this ships in the open like any OAuth public client_id.
-# ponytail: no baked default yet — set HUMALIKE_CLI_GATEWAY_KEY until the
-# published identifier lands here in a follow-up.
-GATEWAY_KEY_DEFAULT = ""
+# this ships in the open like any OAuth public client_id. Override with
+# HUMALIKE_CLI_GATEWAY_KEY (e.g. for staging).
+GATEWAY_KEY_DEFAULT = "hcg_360rQLmr4iabWKiEqc5ZFXY5sUM8g-wTjFO3cwNgTlI"
 
 _MARKER = Path.home() / ".hermes" / ".turn_taking_login_prompted"
 
@@ -146,6 +148,9 @@ def run() -> int:
 
     uri = session["verification_uri"]
     minutes = max(1, int(session.get("expires_in", 600)) // 60)
+    # print for the terminal AND log for gateway/TUI runs, where a rich UI can
+    # swallow a background thread's stdout — the log file keeps the URL findable.
+    _log.warning("humalike login: approve at %s (valid ~%d min)", uri, minutes)
     print("\nOpen this link on any device and approve to connect your Humalike account:\n"
           f"\n    {uri}\n"
           f"\nWaiting for approval (link valid ~{minutes} min, Ctrl-C to abort)…")
@@ -178,7 +183,13 @@ def maybe_first_boot_login() -> None:
     Marker written when the prompt FIRES, not on success — an ignored tab must
     not reopen on every boot. Retry paths: delete the marker, rerun login.py,
     or send /connect."""
-    if cfg("HUMALIKE_API_KEY") or not gateway_key() or _MARKER.exists():
+    if cfg("HUMALIKE_API_KEY"):
+        return  # already connected
+    if not gateway_key():
+        _log.info("humalike login: skipped — no client identifier configured")
+        return
+    if _MARKER.exists():
+        _log.info("humalike login: already prompted once (delete %s to retry, or send /connect)", _MARKER)
         return
     try:
         _MARKER.parent.mkdir(parents=True, exist_ok=True)

--- a/login.py
+++ b/login.py
@@ -217,7 +217,8 @@ def run(wait_for_tui: bool = False) -> int:
         pass
     if wait_for_tui:
         _wait_for_tui()
-    _show("\nOpen this link on any device and approve to connect your Humalike account:\n"
+    _show("\n🔗 Humalike plugin — one step left: connect your account.\n"
+          "   Open this link on any device (your phone works) and approve:\n"
           f"\n    {uri}\n"
           f"\nWaiting for approval (link valid ~{minutes} min)…\n")
 

--- a/login.py
+++ b/login.py
@@ -106,6 +106,24 @@ def _show(text: str) -> None:
     print(text)
 
 
+def _wait_for_tui(timeout: float = 8.0) -> None:
+    """Hold the FIRST link display until the hermes TUI has painted, so it
+    prints through run_in_terminal right below the banner instead of being
+    buried above it. Returns fast when no TUI is coming: immediately when
+    prompt_toolkit is absent (bare console), on timeout in the gateway."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            from prompt_toolkit.application import get_app_or_none
+        except Exception:
+            return
+        app = get_app_or_none()
+        if app is not None and app.is_running:
+            time.sleep(0.3)  # let the banner finish painting
+            return
+        time.sleep(0.2)
+
+
 # ── Key persistence ───────────────────────────────────────────────────────────
 def write_env_key(path: Path, key: str) -> None:
     """Upsert ``HUMALIKE_API_KEY=…``, preserving every other line. A fresh file
@@ -165,8 +183,12 @@ def poll_session(session: dict, bearer: str, on_wait=None) -> dict:
 
 
 # ── Terminal flow ─────────────────────────────────────────────────────────────
-def run() -> int:
-    """0 = key saved (or already present), 1 = failed/denied/expired."""
+def run(wait_for_tui: bool = False) -> int:
+    """0 = key saved (or already present), 1 = failed/denied/expired.
+
+    ``wait_for_tui`` (the first-boot path inside hermes): delay the first
+    link display until the TUI is up, so the link lands BELOW the banner —
+    a pre-banner print just scrolls out of sight."""
     if cfg("HUMALIKE_API_KEY"):
         print("Already connected — HUMALIKE_API_KEY is set.")
         return 0
@@ -183,23 +205,24 @@ def run() -> int:
 
     uri = session["verification_uri"]
     minutes = max(1, int(session.get("expires_in", 600)) // 60)
-    # print for the terminal AND log for gateway/TUI runs, where a rich UI can
-    # swallow a background thread's stdout — the log file keeps the URL findable.
+    # Log first (always findable), open the browser ASAP (desktop case), and
+    # only THEN display — after the TUI is up when asked, so the link prints
+    # below the banner via run_in_terminal instead of scrolling away above it.
     _log.warning("humalike login: approve at %s (valid ~%d min)", uri, minutes)
-    _show("\nOpen this link on any device and approve to connect your Humalike account:\n"
-          f"\n    {uri}\n"
-          f"\nWaiting for approval (link valid ~{minutes} min)…")
     try:
         import webbrowser
 
         webbrowser.open(uri)  # pops a tab on a desktop; harmless no-op headless
     except Exception:
         pass
+    if wait_for_tui:
+        _wait_for_tui()
+    _show("\nOpen this link on any device and approve to connect your Humalike account:\n"
+          f"\n    {uri}\n"
+          f"\nWaiting for approval (link valid ~{minutes} min)…")
 
-    # The hermes TUI banner paints over the first print (it renders a beat
-    # after plugin registration) — re-print while pending so the link lands in
-    # view. /connect also re-shows PENDING_URI on demand.
-    reminders = {15, 60, 180}
+    # Gentle nudges while pending; /connect also re-shows PENDING_URI on demand.
+    reminders = {60, 180}
 
     def _remind(elapsed: float) -> None:
         due = {t for t in reminders if t <= elapsed}
@@ -249,7 +272,7 @@ def maybe_first_boot_login() -> None:
         _MARKER.write_text("1")
     except OSError:
         pass  # best-effort; worst case the prompt repeats next boot
-    threading.Thread(target=run, daemon=True, name="humalike-login").start()
+    threading.Thread(target=lambda: run(wait_for_tui=True), daemon=True, name="humalike-login").start()
 
 
 if __name__ == "__main__":

--- a/login.py
+++ b/login.py
@@ -1,10 +1,17 @@
-"""Device-authorization login (stdlib only, no httpx).
+#!/usr/bin/env python3
+"""Terminal device-authorization login — the install-time cousin of /connect.
+
+Run it right after installing the plugin (stdlib only — no Hermes venv, no
+httpx):
+
+    python3 ~/.hermes/plugins/humalike/login.py
 
 Prints the approval URL (and opens a browser tab when the machine has one — on
 SSH/headless boxes open the printed link on your phone), polls until the link
 is approved, then writes HUMALIKE_API_KEY into ``~/.hermes/.env``.
 
-Two callers share this module (it is not a standalone script):
+Three callers share this module:
+  * the terminal (``__main__``) — install-time login,
   * ``register()`` via :func:`maybe_first_boot_login` — pops the login once on
     the first keyless gateway boot (marker-guarded),
   * ``connect.py`` — reuses :func:`poll_session` and :func:`write_env_key`.
@@ -20,6 +27,7 @@ import logging
 import os
 import platform
 import socket
+import sys
 import threading
 import time
 import urllib.request
@@ -30,13 +38,12 @@ _log = logging.getLogger(__name__)
 def _hermes_home() -> Path:
     """The real hermes home: the host's single source of truth when importable
     (HERMES_HOME-aware, platform-native defaults), else the env var, else
-    ``~/.hermes`` (when hermes_constants isn't importable)."""
+    ``~/.hermes`` (login.py run standalone outside the hermes venv)."""
     try:
         from hermes_constants import get_hermes_home  # noqa: PLC0415
 
         return Path(get_hermes_home())
     except Exception:
-        # hermes_constants not importable (e.g. imported outside the gateway venv)
         return Path(os.getenv("HERMES_HOME") or "~/.hermes").expanduser()
 
 
@@ -193,7 +200,7 @@ def poll_session(session: dict, bearer: str, on_wait=None) -> dict:
     return {"status": "expired"}
 
 
-# ── Login flow (internal; run on a daemon thread by maybe_first_boot_login) ───
+# ── Terminal flow ─────────────────────────────────────────────────────────────
 def run(wait_for_tui: bool = False) -> int:
     """0 = key saved (or already present), 1 = failed/denied/expired.
 
@@ -258,7 +265,7 @@ def run(wait_for_tui: bool = False) -> int:
         _show(f"\n✅ Connected as {who} — key saved to {HERMES_ENV}.\n")
         return 0
     _log.warning("humalike login: %s", status)
-    _show(f"\nLogin {status} — send the bot /connect to retry.\n")
+    _show(f"\nLogin {status} — send the bot /connect (or rerun login.py) to retry.\n")
     return 1
 
 
@@ -269,8 +276,8 @@ def maybe_first_boot_login() -> None:
     daemon thread so boot never blocks on the ~10-minute approval window.
 
     Marker written when the prompt FIRES, not on success — an ignored tab must
-    not reopen on every boot. Retry paths: delete the marker and restart, or
-    send /connect."""
+    not reopen on every boot. Retry paths: delete the marker, rerun login.py,
+    or send /connect."""
     if cfg("HUMALIKE_API_KEY"):
         return  # already connected
     if not gateway_key():
@@ -285,3 +292,7 @@ def maybe_first_boot_login() -> None:
     except OSError:
         pass  # best-effort; worst case the prompt repeats next boot
     threading.Thread(target=lambda: run(wait_for_tui=True), daemon=True, name="humalike-login").start()
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/login.py
+++ b/login.py
@@ -265,11 +265,16 @@ def run(wait_for_tui: bool = False) -> int:
     # only THEN display — after the TUI is up when asked, so the link prints
     # below the banner via run_in_terminal instead of scrolling away above it.
     _log.warning("humalike login: approve at %s (valid ~%d min)", uri, minutes)
-    # Plain stdout too, flushed: the TUI-safe _show routes through the prompt
-    # app's terminal, which `docker compose logs` (stdout) never sees — this
-    # line is the one a headless/containerized operator can actually read.
-    print(f"[Humalike] Connect your account — approve at: {uri}  (valid ~{minutes} min)",
-          flush=True)
+    # Headless/containerized: write straight to fd 1 so the link reaches
+    # `docker compose logs` even when a TUI or a logging redirect owns
+    # sys.stdout. Guarded to non-TTY only — on a real terminal a raw write
+    # would fight prompt_toolkit for the screen; there _show renders it cleanly.
+    if not sys.stdout.isatty():
+        try:
+            os.write(1, (f"[Humalike] Connect your account — approve at: {uri}  "
+                         f"(valid ~{minutes} min)\n").encode())
+        except OSError:
+            pass
     try:
         import webbrowser
 

--- a/login.py
+++ b/login.py
@@ -53,10 +53,9 @@ DEFAULT_API = "https://api.humalike.com"
 CREATE = "/v1/keys/actions/cli_create"
 POLL = "/v1/keys/actions/cli_poll"
 # Key-validation probe: authed by the USER key (Bearer HUMALIKE_API_KEY), 200 =
-# works, 401/403 = dead. None until the svc-keys endpoint lands — while None,
-# a present key counts as working (no network call, no needless re-login).
-# TODO: set to the whoami/validate path once it exists (see the server ticket).
-WHOAMI_PATH: str | None = None
+# works, 401/403 = dead. svc-turn-taking whoami — a zero-side-effect identity
+# echo (POST {}, returns {user_id}), safe to call on every start.
+WHOAMI_PATH: str | None = "/v1/turn-taking/actions/whoami"
 
 # RFC 8628 public client identifier for the CLI lane: it names the client (a
 # Hermes plugin install) to the API and unlocks ONLY cli_create/cli_poll — the

--- a/login.py
+++ b/login.py
@@ -4,7 +4,7 @@
 Run it right after installing the plugin (stdlib only — no Hermes venv, no
 httpx):
 
-    python3 ~/.hermes/plugins/turn-taking/login.py
+    python3 ~/.hermes/plugins/humalike/login.py
 
 Prints the approval URL (and opens a browser tab when the machine has one — on
 SSH/headless boxes open the printed link on your phone), polls until the link

--- a/login.py
+++ b/login.py
@@ -35,7 +35,19 @@ from pathlib import Path
 
 _log = logging.getLogger(__name__)
 
-HERMES_ENV = Path.home() / ".hermes" / ".env"
+def _hermes_home() -> Path:
+    """The real hermes home: the host's single source of truth when importable
+    (HERMES_HOME-aware, platform-native defaults), else the env var, else
+    ``~/.hermes`` (login.py run standalone outside the hermes venv)."""
+    try:
+        from hermes_constants import get_hermes_home  # noqa: PLC0415
+
+        return Path(get_hermes_home())
+    except Exception:
+        return Path(os.getenv("HERMES_HOME") or "~/.hermes").expanduser()
+
+
+HERMES_ENV = _hermes_home() / ".env"
 DEFAULT_API = "https://api.humalike.com"
 CREATE = "/v1/keys/actions/cli_create"
 POLL = "/v1/keys/actions/cli_poll"
@@ -47,7 +59,7 @@ POLL = "/v1/keys/actions/cli_poll"
 # HUMALIKE_CLI_GATEWAY_KEY (e.g. for staging).
 GATEWAY_KEY_DEFAULT = "hcg_360rQLmr4iabWKiEqc5ZFXY5sUM8g-wTjFO3cwNgTlI"
 
-_MARKER = Path.home() / ".hermes" / ".turn_taking_login_prompted"
+_MARKER = _hermes_home() / ".turn_taking_login_prompted"
 
 # The not-yet-approved link, while a login (first-boot or /connect) is in
 # flight — None when idle. Lets /connect RE-SHOW the pending link instead of

--- a/login.py
+++ b/login.py
@@ -49,6 +49,11 @@ GATEWAY_KEY_DEFAULT = "hcg_360rQLmr4iabWKiEqc5ZFXY5sUM8g-wTjFO3cwNgTlI"
 
 _MARKER = Path.home() / ".hermes" / ".turn_taking_login_prompted"
 
+# The not-yet-approved link, while a login (first-boot or /connect) is in
+# flight — None when idle. Lets /connect RE-SHOW the pending link instead of
+# starting a duplicate session (a TUI banner can paint over the first print).
+PENDING_URI = None
+
 
 # ── Config (env first, then ~/.hermes/.env) ───────────────────────────────────
 def read_env_file(path: Path | None = None) -> dict:
@@ -111,15 +116,22 @@ def create_session(bearer: str) -> dict:
                          "os": platform.system()}, bearer)
 
 
-def poll_session(session: dict, bearer: str) -> dict:
+def poll_session(session: dict, bearer: str, on_wait=None) -> dict:
     """Blocking poll until a terminal status; returns the final poll body
     (``{'status': 'expired'}`` synthesized on TTL). Any HTTP error is transient
     by contract — keep polling; the session TTL is the real deadline. Unknown
-    future statuses are treated as pending."""
+    future statuses are treated as pending. ``on_wait(elapsed_seconds)`` is
+    called once per loop — the terminal flow uses it to re-print the link."""
     interval = max(1, int(session.get("interval", 3)))
-    deadline = time.monotonic() + int(session.get("expires_in", 600))
+    start = time.monotonic()
+    deadline = start + int(session.get("expires_in", 600))
     while time.monotonic() < deadline:
         time.sleep(interval)
+        if on_wait is not None:
+            try:
+                on_wait(time.monotonic() - start)
+            except Exception:
+                pass
         try:
             data = post(POLL, {"device_code": session["device_code"]}, bearer)
         except Exception:
@@ -161,7 +173,23 @@ def run() -> int:
     except Exception:
         pass
 
-    data = poll_session(session, bearer)
+    # The hermes TUI banner paints over the first print (it renders a beat
+    # after plugin registration) — re-print while pending so the link lands in
+    # view. /connect also re-shows PENDING_URI on demand.
+    reminders = {15, 60, 180}
+
+    def _remind(elapsed: float) -> None:
+        due = {t for t in reminders if t <= elapsed}
+        if due:
+            reminders.difference_update(due)
+            print(f"\n⏳ Humalike login still waiting — approve at: {uri}\n")
+
+    global PENDING_URI
+    PENDING_URI = uri
+    try:
+        data = poll_session(session, bearer, on_wait=_remind)
+    finally:
+        PENDING_URI = None
     status = data.get("status")
     if status == "authorized":
         key = data.get("api_key") or ""

--- a/login.py
+++ b/login.py
@@ -219,7 +219,7 @@ def run(wait_for_tui: bool = False) -> int:
         _wait_for_tui()
     _show("\nOpen this link on any device and approve to connect your Humalike account:\n"
           f"\n    {uri}\n"
-          f"\nWaiting for approval (link valid ~{minutes} min)…")
+          f"\nWaiting for approval (link valid ~{minutes} min)…\n")
 
     # Gentle nudges while pending; /connect also re-shows PENDING_URI on demand.
     reminders = {60, 180}

--- a/login.py
+++ b/login.py
@@ -83,6 +83,29 @@ def api_url() -> str:
     return cfg("HUMALIKE_API_URL", DEFAULT_API).rstrip("/")
 
 
+# ── TUI-safe printing ─────────────────────────────────────────────────────────
+def _show(text: str) -> None:
+    """Print so it survives the hermes TUI. Under a running prompt_toolkit
+    application a bare print() is erased on the next redraw — route through
+    run_in_terminal (hermes cli.py's own idiom), which suspends the prompt,
+    prints above it into scrollback, and resumes. Plain print everywhere else
+    (gateway console, bare terminal, prompt_toolkit not installed)."""
+    try:
+        from prompt_toolkit.application import get_app_or_none, run_in_terminal
+
+        app = get_app_or_none()
+        if app is not None and app.is_running and getattr(app, "loop", None) is not None:
+            import asyncio
+
+            app.loop.call_soon_threadsafe(
+                lambda: asyncio.ensure_future(run_in_terminal(lambda: print(text)))
+            )
+            return
+    except Exception:
+        pass  # fall through to the plain print
+    print(text)
+
+
 # ── Key persistence ───────────────────────────────────────────────────────────
 def write_env_key(path: Path, key: str) -> None:
     """Upsert ``HUMALIKE_API_KEY=…``, preserving every other line. A fresh file
@@ -155,7 +178,7 @@ def run() -> int:
     try:
         session = create_session(bearer)
     except Exception as e:
-        print(f"Could not reach Humalike to start the login ({e}).")
+        _show(f"Could not reach Humalike to start the login ({e}).")
         return 1
 
     uri = session["verification_uri"]
@@ -163,9 +186,9 @@ def run() -> int:
     # print for the terminal AND log for gateway/TUI runs, where a rich UI can
     # swallow a background thread's stdout — the log file keeps the URL findable.
     _log.warning("humalike login: approve at %s (valid ~%d min)", uri, minutes)
-    print("\nOpen this link on any device and approve to connect your Humalike account:\n"
+    _show("\nOpen this link on any device and approve to connect your Humalike account:\n"
           f"\n    {uri}\n"
-          f"\nWaiting for approval (link valid ~{minutes} min, Ctrl-C to abort)…")
+          f"\nWaiting for approval (link valid ~{minutes} min)…")
     try:
         import webbrowser
 
@@ -182,7 +205,7 @@ def run() -> int:
         due = {t for t in reminders if t <= elapsed}
         if due:
             reminders.difference_update(due)
-            print(f"\n⏳ Humalike login still waiting — approve at: {uri}\n")
+            _show(f"\n⏳ Humalike login still waiting — approve at: {uri}\n")
 
     global PENDING_URI
     PENDING_URI = uri
@@ -196,9 +219,11 @@ def run() -> int:
         write_env_key(HERMES_ENV, key)
         os.environ["HUMALIKE_API_KEY"] = key  # live for this process too
         who = (data.get("account") or {}).get("email") or "your account"
-        print(f"✅ Connected as {who} — key saved to {HERMES_ENV}.")
+        _log.warning("humalike login: connected as %s", who)
+        _show(f"\n✅ Connected as {who} — key saved to {HERMES_ENV}.\n")
         return 0
-    print(f"Login {status} — run this script again (or send the bot /connect) to retry.")
+    _log.warning("humalike login: %s", status)
+    _show(f"\nLogin {status} — send the bot /connect (or rerun login.py) to retry.\n")
     return 1
 
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,4 +1,4 @@
-name: turn-taking
+name: humalike
 version: 0.1.0
 description: "Decides when the agent should speak (stays silent otherwise) and naturalizes each reply into 1-5 chat messages via the external turn-taking service. v1 joins the messages into one bubble (no pacing)."
 author: humalike

--- a/skills/configure-slack-group/SKILL.md
+++ b/skills/configure-slack-group/SKILL.md
@@ -37,6 +37,18 @@ Channel IDs: gateway logs after a message from that channel, or the Slack URL
 (`.../C0123456789/...`). config.yaml equivalents: `require_mention: false` /
 `free_response_channels: [...]` under `slack:`.
 
+**Gate C — one conversation per channel (REQUIRED for turn-taking)** — in
+`~/.hermes/config.yaml`:
+```yaml
+slack:
+  reply_in_thread: false
+```
+With the default (`true`), every top-level channel message becomes its own
+synthetic thread AND its own session — the bot answers each message separately
+in a separate thread and turn-taking can never coalesce the conversation. With
+`false` the whole channel shares one session and the bot replies once, to the
+latest message (replies inside existing threads stay threaded).
+
 Fully open = `SLACK_ALLOW_ALL_USERS=true` + `SLACK_REQUIRE_MENTION=false` —
 weigh the fail-open caveat before doing this on a busy/public workspace.
 If disabling mentions globally, consider `SLACK_ALLOWED_CHANNELS=<ids>` so the

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -45,6 +45,10 @@ same login automatically, and `/connect` in chat (step 4) is the fallback.
 
 ## 3. Required config
 
+The plugin applies the settings below AUTOMATICALLY on its first boot (and
+prompts Telegram's manual steps) — treat this section as verify/override, or
+apply it by hand when the gateway can't be restarted twice.
+
 First find where SOUL.md actually lives: check `~/.hermes/SOUL.md`; if it's not
 there, search the Hermes install for an existing one (e.g. a `docker/SOUL.md`
 or a path mounted into the gateway). If none exists anywhere, use
@@ -79,6 +83,11 @@ device — the key is then saved to `~/.hermes/.env` and goes live without
 another restart.
 
 ## Platform notes
+
+WhatsApp and Slack respond-to-everyone settings are auto-applied on the
+plugin's first boot for platforms already connected (only filling values the
+operator hasn't set). The skills below remain for Telegram (always manual),
+later-added platforms, and overrides:
 
 - **WhatsApp groups** — respond to everyone: `configure-whatsapp-group` skill.
 - **Telegram groups** — privacy mode + chat authorization: `configure-telegram-group` skill.

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -26,22 +26,16 @@ hermes plugins enable humalike
 ## 2. Connect the Humalike account
 
 No env vars needed. If the user already has an API key, put it in
-`~/.hermes/.env` (create if missing) and skip the login:
+`~/.hermes/.env` (create if missing):
 
 ```bash
 HUMALIKE_API_KEY=their-api-key   # optional — only when they already have one
 ```
 
-Otherwise run the device login now, in the terminal:
-
-```bash
-python3 ~/.hermes/plugins/humalike/login.py
-```
-
-It prints the approval URL and opens a browser tab when the install machine
-has one; the user approves on any device (phone works) and the key lands in
-`.env` before first boot. If you skip this, the first gateway start pops the
-same login automatically, and `/connect` in chat (step 4) is the fallback.
+Otherwise leave it unset: the first Hermes start (step 4) prints a login URL on
+the console (and opens a browser tab when the machine has one). The user
+approves on any device (phone works) and the key is saved to `~/.hermes/.env`.
+`/connect` in chat does the same at any time.
 
 ## 3. Required config
 

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -67,7 +67,6 @@ slack:
 
 turn_taking:
   soul_path: "<the SOUL.md path found above>"
-  soul_grounding: "off"    # off | web | research — real-world research on enhance
   soul_auto_enhance: true  # one-shot persona enhance on first startup
 ```
 

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -17,11 +17,11 @@ sending the bot `/connect` (a login link, approved in any browser).
 ## 1. Clone and enable
 
 ```bash
-git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/turn-taking
+git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/humalike
 
 # `hermes` must be the Hermes CLI from its install — activate the Hermes
 # virtualenv first (or call the hermes CLI by its full path)
-hermes plugins enable turn-taking
+hermes plugins enable humalike
 ```
 
 ## 2. Env vars
@@ -39,7 +39,7 @@ HUMALIKE_CLI_GATEWAY_KEY=…      # only for the login/connect flow — the plug
 No API key? Run the device login right now, in the terminal:
 
 ```bash
-python3 ~/.hermes/plugins/turn-taking/login.py
+python3 ~/.hermes/plugins/humalike/login.py
 ```
 
 It prints the approval URL and opens a browser tab when the install machine

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -62,6 +62,8 @@ streaming: false
 group_sessions_per_user: false
 display:
   tool_progress: "off"   # hide tool-call chatter (Browsing/Clicking/…) so replies read as human
+slack:
+  reply_in_thread: false # only if Slack is used — one shared conversation per channel
 
 turn_taking:
   soul_path: "<the SOUL.md path found above>"

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -9,8 +9,10 @@ Humalike plugin for [Hermes Agent](https://github.com/NousResearch/hermes-agent)
 turn-taking, persona (`/soul enhance`), theory of mind, social learning.
 API docs: <https://docs.humalike.com>.
 
-Do the steps in order. Ask the user only for the value marked **ask** (the API
-key); the URL defaults to `https://api.humalike.com`.
+Do the steps in order. The URL defaults to `https://api.humalike.com`. For the
+API key, ask whether the user already has one: if yes, set it in step 2; if
+not, skip it there — after the restart in step 4 they link their account by
+sending the bot `/connect` (a login link, approved in any browser).
 
 ## 1. Clone and enable
 
@@ -29,7 +31,7 @@ Humalike calls, sent as `Authorization: Bearer`:
 
 ```bash
 HUMALIKE_API_URL=https://api.humalike.com
-HUMALIKE_API_KEY=your-api-key                 # ask
+HUMALIKE_API_KEY=your-api-key   # ask — omit if the user will link via /connect
 ```
 
 ## 3. Required config
@@ -60,6 +62,11 @@ Restart the Hermes gateway, then send the bot a message. A `tt inbound: chat=…
 line in `~/.hermes/logs/gateway.log` confirms turn-taking is intercepting
 messages. If none appears, `HUMALIKE_API_URL` isn't set in the gateway's
 environment — turn-taking stays disabled (`/soul` still works).
+
+No API key set in step 2? Have the user send the bot `/connect` (from a DM,
+not a group): it replies with a login link they approve in a browser on any
+device — the key is then saved to `~/.hermes/.env` and goes live without
+another restart.
 
 ## Platform notes
 

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -9,10 +9,9 @@ Humalike plugin for [Hermes Agent](https://github.com/NousResearch/hermes-agent)
 turn-taking, persona (`/soul enhance`), theory of mind, social learning.
 API docs: <https://docs.humalike.com>.
 
-Do the steps in order. The URL defaults to `https://api.humalike.com`. For the
-API key, ask whether the user already has one: if yes, set it in step 2; if
-not, skip it there — after the restart in step 4 they link their account by
-sending the bot `/connect` (a login link, approved in any browser).
+Do the steps in order. No env setup is required: the API URL defaults to
+`https://api.humalike.com` and the API key comes from a device login (step 2).
+Only ask for a key if the user says they already have one.
 
 ## 1. Clone and enable
 
@@ -24,19 +23,16 @@ git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/h
 hermes plugins enable humalike
 ```
 
-## 2. Env vars
+## 2. Connect the Humalike account
 
-In `~/.hermes/.env` (create if missing) — one URL + one key covers all
-Humalike calls, sent as `Authorization: Bearer`:
+No env vars needed. If the user already has an API key, put it in
+`~/.hermes/.env` (create if missing) and skip the login:
 
 ```bash
-HUMALIKE_API_URL=https://api.humalike.com
-HUMALIKE_API_KEY=your-api-key   # ask — omit if the user will link via login.py or /connect
-HUMALIKE_CLI_GATEWAY_KEY=…      # only for the login/connect flow — the plugin's
-                                # public client id (see the Humalike docs)
+HUMALIKE_API_KEY=their-api-key   # optional — only when they already have one
 ```
 
-No API key? Run the device login right now, in the terminal:
+Otherwise run the device login now, in the terminal:
 
 ```bash
 python3 ~/.hermes/plugins/humalike/login.py
@@ -44,9 +40,8 @@ python3 ~/.hermes/plugins/humalike/login.py
 
 It prints the approval URL and opens a browser tab when the install machine
 has one; the user approves on any device (phone works) and the key lands in
-`.env` before first boot. Requires `HUMALIKE_CLI_GATEWAY_KEY` above. If you
-skip this, the first gateway start pops the same login automatically, and
-`/connect` in chat (step 4) is the fallback.
+`.env` before first boot. If you skip this, the first gateway start pops the
+same login automatically, and `/connect` in chat (step 4) is the fallback.
 
 ## 3. Required config
 
@@ -74,8 +69,9 @@ turn_taking:
 
 Restart the Hermes gateway, then send the bot a message. A `tt inbound: chat=…`
 line in `~/.hermes/logs/gateway.log` confirms turn-taking is intercepting
-messages. If none appears, `HUMALIKE_API_URL` isn't set in the gateway's
-environment — turn-taking stays disabled (`/soul` still works).
+messages. If none appears, the plugin didn't load — check it shows as enabled
+in `hermes plugins list` (or `HUMALIKE_API_URL` was explicitly set empty,
+which disables turn-taking; `/soul` still works).
 
 No API key set in step 2? Have the user send the bot `/connect` (from a DM,
 not a group): it replies with a login link they approve in a browser on any

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -32,6 +32,8 @@ Humalike calls, sent as `Authorization: Bearer`:
 ```bash
 HUMALIKE_API_URL=https://api.humalike.com
 HUMALIKE_API_KEY=your-api-key   # ask — omit if the user will link via /connect
+HUMALIKE_CLI_GATEWAY_KEY=…      # only for the /connect flow — the plugin's
+                                # public client id (see the Humalike docs)
 ```
 
 ## 3. Required config

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -31,10 +31,22 @@ Humalike calls, sent as `Authorization: Bearer`:
 
 ```bash
 HUMALIKE_API_URL=https://api.humalike.com
-HUMALIKE_API_KEY=your-api-key   # ask — omit if the user will link via /connect
-HUMALIKE_CLI_GATEWAY_KEY=…      # only for the /connect flow — the plugin's
+HUMALIKE_API_KEY=your-api-key   # ask — omit if the user will link via login.py or /connect
+HUMALIKE_CLI_GATEWAY_KEY=…      # only for the login/connect flow — the plugin's
                                 # public client id (see the Humalike docs)
 ```
+
+No API key? Run the device login right now, in the terminal:
+
+```bash
+python3 ~/.hermes/plugins/turn-taking/login.py
+```
+
+It prints the approval URL and opens a browser tab when the install machine
+has one; the user approves on any device (phone works) and the key lands in
+`.env` before first boot. Requires `HUMALIKE_CLI_GATEWAY_KEY` above. If you
+skip this, the first gateway start pops the same login automatically, and
+`/connect` in chat (step 4) is the fallback.
 
 ## 3. Required config
 

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -26,16 +26,22 @@ hermes plugins enable humalike
 ## 2. Connect the Humalike account
 
 No env vars needed. If the user already has an API key, put it in
-`~/.hermes/.env` (create if missing):
+`~/.hermes/.env` (create if missing) and skip the login:
 
 ```bash
 HUMALIKE_API_KEY=their-api-key   # optional — only when they already have one
 ```
 
-Otherwise leave it unset: the first Hermes start (step 4) prints a login URL on
-the console (and opens a browser tab when the machine has one). The user
-approves on any device (phone works) and the key is saved to `~/.hermes/.env`.
-`/connect` in chat does the same at any time.
+Otherwise run the device login now, in the terminal:
+
+```bash
+python3 ~/.hermes/plugins/humalike/login.py
+```
+
+It prints the approval URL and opens a browser tab when the install machine
+has one; the user approves on any device (phone works) and the key lands in
+`.env` before first boot. If you skip this, the first gateway start pops the
+same login automatically, and `/connect` in chat (step 4) is the fallback.
 
 ## 3. Required config
 

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -9,9 +9,12 @@ Humalike plugin for [Hermes Agent](https://github.com/NousResearch/hermes-agent)
 turn-taking, persona (`/soul enhance`), theory of mind, social learning.
 API docs: <https://docs.humalike.com>.
 
-Do the steps in order. No env setup is required: the API URL defaults to
-`https://api.humalike.com` and the API key comes from a device login (step 2).
-Only ask for a key if the user says they already have one.
+The normal flow is just **clone → enable → start `hermes`**: starting the
+gateway is what applies the required config and pops the login, so steps 2–3
+below are mostly what that first start does for you, plus the manual fallbacks.
+No env setup is required — the API URL defaults to `https://api.humalike.com`
+and the API key comes from the device login. Only ask for a key if the user
+says they already have one. Do the steps in order.
 
 ## 1. Clone and enable
 
@@ -23,25 +26,34 @@ git clone https://github.com/Humalike/hermes-humalike-plugin ~/.hermes/plugins/h
 hermes plugins enable humalike
 ```
 
-## 2. Connect the Humalike account
+## 2. Start Hermes — this applies the config and pops the login
 
-No env vars needed. If the user already has an API key, put it in
-`~/.hermes/.env` (create if missing) and skip the login:
-
-```bash
-HUMALIKE_API_KEY=their-api-key   # optional — only when they already have one
-```
-
-Otherwise run the device login now, in the terminal:
+`hermes plugins enable` only records the plugin; nothing runs until the gateway
+starts. Start it (activate the Hermes virtualenv first, or use your gateway
+start command):
 
 ```bash
-python3 ~/.hermes/plugins/humalike/login.py
+hermes
 ```
 
-It prints the approval URL and opens a browser tab when the install machine
-has one; the user approves on any device (phone works) and the key lands in
-`.env` before first boot. If you skip this, the first gateway start pops the
-same login automatically, and `/connect` in chat (step 4) is the fallback.
+On this first start the plugin self-configures (step 3) and prints a device
+login URL — opening a browser tab when the machine has one. The user approves
+on any device (a phone works) and the key is saved to `~/.hermes/.env`.
+
+Two ways to skip that login:
+
+- **Already have a key** — put it in `~/.hermes/.env` (create if missing)
+  *before* starting, and the login isn't shown:
+  ```bash
+  HUMALIKE_API_KEY=their-api-key
+  ```
+- **Headless / can't keep the terminal open** — run the same login by hand:
+  ```bash
+  python3 ~/.hermes/plugins/humalike/login.py
+  ```
+
+If the login is dismissed, `/connect` in chat (step 4) links an account later
+without a restart.
 
 ## 3. Required config
 

--- a/social_learning/__init__.py
+++ b/social_learning/__init__.py
@@ -238,6 +238,33 @@ def _refresh_card(session_id: str, conversation_history: Any) -> None:
         notify.alert_social(exc)
 
 
+# ── Detached refresh (shared by warm-up and the per-turn hook) ───────────────
+_REFRESHING: set = set()  # session ids with a refresh thread in flight
+
+
+def _spawn_refresh(session_id: str, history: Any) -> bool:
+    """Start a detached ``_refresh_card`` unless one is already in flight for
+    this session — at most one concurrent POST per session, so a slow or dead
+    service costs one 60s thread per session, not one per message (the no-card
+    branch fires every turn). Returns True if a thread was spawned.
+    ponytail: in-flight guard only; add time-based backoff if per-turn retries
+    against a dead service ever matter."""
+    with _LOCK:
+        if session_id in _REFRESHING:
+            return False
+        _REFRESHING.add(session_id)
+
+    def _run() -> None:
+        try:
+            _refresh_card(session_id, history)
+        finally:
+            with _LOCK:
+                _REFRESHING.discard(session_id)
+
+    threading.Thread(target=_run, daemon=True).start()
+    return True
+
+
 # ── Startup warm-up ──────────────────────────────────────────────────────────
 WARM_SESSIONS: int = 5
 
@@ -268,9 +295,7 @@ def warm_recent_sessions(limit: int = WARM_SESSIONS) -> None:
             if not session_id or already_cached:
                 continue
             history = db.get_messages_as_conversation(session_id)
-            threading.Thread(
-                target=_refresh_card, args=(session_id, history), daemon=True
-            ).start()
+            _spawn_refresh(session_id, history)
         logger.info("social-learning: warm-up fired for up to %d recent session(s)", len(sessions))
     except Exception as exc:
         logger.debug("social-learning: warm_recent_sessions failed: %s", exc)
@@ -296,15 +321,11 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[Dict[str, Any]]:
         )
 
         if (not has_card or n % REFRESH_EVERY == 0) and _get_service_url():
-            logger.info(
-                "social-learning: turn %d session %s — firing detached refresh (%s)",
-                n, session_id, "no card yet" if not has_card else "scheduled",
-            )
-            threading.Thread(
-                target=_refresh_card,
-                args=(session_id, list(conversation_history)),
-                daemon=True,
-            ).start()
+            if _spawn_refresh(session_id, list(conversation_history)):
+                logger.info(
+                    "social-learning: turn %d session %s — firing detached refresh (%s)",
+                    n, session_id, "no card yet" if not has_card else "scheduled",
+                )
 
         with _LOCK:
             card = _CACHE.get(session_id)

--- a/social_learning/__init__.py
+++ b/social_learning/__init__.py
@@ -238,6 +238,44 @@ def _refresh_card(session_id: str, conversation_history: Any) -> None:
         notify.alert_social(exc)
 
 
+# ── Startup warm-up ──────────────────────────────────────────────────────────
+WARM_SESSIONS: int = 5
+
+
+def warm_recent_sessions(limit: int = WARM_SESSIONS) -> None:
+    """Build voice cards for the ``limit`` most-recently-active sessions at
+    plugin registration, instead of waiting for each session's first
+    ``pre_llm_call``. Read-only DB access (no write-lock contention with the
+    live gateway); each session's history is fetched via the same
+    ``get_messages_as_conversation`` the gateway itself uses to restore
+    context, so the very first reply after a fresh install already has a
+    card if that session has prior history. Best-effort: never raises."""
+    try:
+        if not _get_service_url():
+            return
+        from hermes_constants import get_hermes_home  # noqa: PLC0415
+        from hermes_state import SessionDB  # noqa: PLC0415
+
+        db_path = get_hermes_home() / "state.db"
+        if not db_path.exists():
+            return
+        db = SessionDB(db_path=db_path, read_only=True)
+        sessions = db.list_sessions_rich(limit=limit, order_by_last_active=True)
+        for s in sessions:
+            session_id = s.get("id")
+            with _LOCK:
+                already_cached = session_id in _CACHE
+            if not session_id or already_cached:
+                continue
+            history = db.get_messages_as_conversation(session_id)
+            threading.Thread(
+                target=_refresh_card, args=(session_id, history), daemon=True
+            ).start()
+        logger.info("social-learning: warm-up fired for up to %d recent session(s)", len(sessions))
+    except Exception as exc:
+        logger.debug("social-learning: warm_recent_sessions failed: %s", exc)
+
+
 # ── Hook ──────────────────────────────────────────────────────────────────────
 def on_pre_llm_call(**kwargs: Any) -> Optional[Dict[str, Any]]:
     """pre_llm_call hook: inject the voice card and (every REFRESH_EVERY turns) refresh it."""
@@ -257,8 +295,11 @@ def on_pre_llm_call(**kwargs: Any) -> Optional[Dict[str, Any]]:
             n, session_id, "cached" if has_card else "none", REFRESH_EVERY,
         )
 
-        if n % REFRESH_EVERY == 0 and _get_service_url():
-            logger.info("social-learning: turn %d session %s — firing detached refresh", n, session_id)
+        if (not has_card or n % REFRESH_EVERY == 0) and _get_service_url():
+            logger.info(
+                "social-learning: turn %d session %s — firing detached refresh (%s)",
+                n, session_id, "no card yet" if not has_card else "scheduled",
+            )
             threading.Thread(
                 target=_refresh_card,
                 args=(session_id, list(conversation_history)),

--- a/social_learning/__init__.py
+++ b/social_learning/__init__.py
@@ -89,8 +89,10 @@ from ..turn_taking import notify  # noqa: E402
 
 
 def _get_service_url() -> str:
-    """Base URL (``HUMALIKE_API_URL``)."""
-    return _config.service_url()
+    """Base URL (``HUMALIKE_API_URL``) — empty while no API key is set, so no
+    conversation transcript ever leaves the machine keyless (the call would
+    401 anyway; /connect un-gates this in-process, no restart needed)."""
+    return _config.service_url() if _config.api_key() else ""
 
 
 def _log_requests_enabled() -> bool:

--- a/social_learning/__init__.py
+++ b/social_learning/__init__.py
@@ -261,7 +261,12 @@ def _spawn_refresh(session_id: str, history: Any) -> bool:
             with _LOCK:
                 _REFRESHING.discard(session_id)
 
-    threading.Thread(target=_run, daemon=True).start()
+    try:
+        threading.Thread(target=_run, daemon=True).start()
+    except Exception:
+        with _LOCK:
+            _REFRESHING.discard(session_id)  # don't leak the guard: the run never happened
+        raise
     return True
 
 

--- a/soul/__init__.py
+++ b/soul/__init__.py
@@ -6,7 +6,7 @@ it borrows from the caller is the genuine ``send`` (passed in) so its replies
 bypass the draft-suppression patch.
 
 Backed by the Humalike Personas API:
-  POST {base}/v1/personas/actions/enhance  {persona, grounding} -> {system_prompt, ...}
+  POST {base}/v1/personas/actions/enhance  {persona} -> {system_prompt, ...}
 
 v1 scope: ENHANCE an existing SOUL.md only. Create-from-scratch is a later add.
 """
@@ -32,7 +32,7 @@ ENHANCEMENT_REPO = "/v1/personas/repositories/Enhancement/by-id/{}"
 DEFAULT_API = "https://api.humalike.com"
 
 # Enhance is async server-side: POST returns {id, status:"pending"}, then we poll
-# the repository route until it's "succeeded"/"failed". research grounding can run
+# the repository route until it's "succeeded"/"failed". enhancement can run
 # for minutes — ponytail: fixed ceiling of POLL_MAX*POLL_EVERY ≈ 5 min, then give up.
 POLL_EVERY = 2.0
 POLL_MAX = 150
@@ -67,11 +67,6 @@ def _soul_path() -> Path:
     return Path(p).expanduser() if p else _HERMES_CONFIG.with_name("SOUL.md")
 
 
-def _grounding() -> str:
-    g = os.getenv("HERMES_SOUL_GROUNDING") or str(_cfg().get("soul_grounding") or "off")
-    return g if g in ("off", "web", "research") else "off"
-
-
 # ── SOUL.md parsing ───────────────────────────────────────────────────────────
 def seed_body(raw: str) -> str:
     """The real persona text in a SOUL.md: HTML comments and markdown headings
@@ -91,11 +86,11 @@ def _persona_text(raw: str) -> str:
 
 # ── Enhance API ───────────────────────────────────────────────────────────────
 # Appended to every persona we enhance so the generated system prompt never uses
-# an em-dash (the LLM's tell). Sent in-band since enhance takes only {persona, grounding}.
+# an em-dash (the LLM's tell). Sent in-band since enhance takes only {persona}.
 _NO_EMDASH_DIRECTIVE = "\n\nHARD RULE: never use an em-dash (—) anywhere in this persona."
 
 
-async def enhance(persona_text: str, grounding: str = "off") -> Optional[Dict[str, Any]]:
+async def enhance(persona_text: str) -> Optional[Dict[str, Any]]:
     """Enhance a persona and return the rendered ``persona`` dict (with
     ``system_prompt``/``fields``/``markdown``), or None on any failure (fail-open).
 
@@ -108,7 +103,7 @@ async def enhance(persona_text: str, grounding: str = "off") -> Optional[Dict[st
         async with httpx.AsyncClient(timeout=30.0) as client:
             r = await client.post(
                 base + ENHANCE_PATH,
-                json={"persona": persona_text + _NO_EMDASH_DIRECTIVE, "grounding": grounding},
+                json={"persona": persona_text + _NO_EMDASH_DIRECTIVE},
                 headers=headers,
             )
             r.raise_for_status()
@@ -164,7 +159,7 @@ async def command(raw_args: str) -> str:
         return ("Your SOUL.md has no persona to enhance yet — add a few lines describing your "
                 "agent, then send /soul enhance. (Generating one from scratch is coming soon.)")
 
-    persona = await enhance(_persona_text(raw), _grounding())
+    persona = await enhance(_persona_text(raw))
     enhanced = (persona or {}).get("system_prompt")
     if not enhanced:
         return "⚠️ Couldn't reach the persona service — SOUL.md left unchanged."
@@ -208,7 +203,7 @@ async def _auto_enhance() -> bool:
     if not seed_body(raw):
         _log.info("soul: auto-enhance skipped — %s has no persona seed yet", path)
         return False
-    persona = await enhance(_persona_text(raw), _grounding())
+    persona = await enhance(_persona_text(raw))
     enhanced = (persona or {}).get("system_prompt")
     if not enhanced:
         _log.warning("soul: auto-enhance failed (service unreachable?) — %s left unchanged", path)

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -82,6 +82,12 @@ def test_whatsapp_fills_only_unset_keys():
     assert not any("GROUP_POLICY" in t for t in fixed)  # preset key untouched
 
 
+def test_whatsapp_opening_up_warns_about_personal_number():
+    _, _, statuses, _, _ = _plan(done={"core"}, env={"WHATSAPP_ENABLED": "true"})
+    warns = [t for k, t in statuses if k == "warn"]
+    assert warns and "personal" in warns[0] and "EVERYONE" in warns[0], statuses
+
+
 def test_whatsapp_already_right_shows_verified():
     _, env_updates, statuses, _, _ = _plan(done={"core"}, env={
         "WHATSAPP_ENABLED": "true", "WHATSAPP_ALLOW_ALL_USERS": "true",

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -167,6 +167,39 @@ def test_upsert_env_updates_many_and_preserves_comments():
         assert "SLACK_REQUIRE_MENTION=true" not in lines
 
 
+def test_corrupt_config_yaml_never_marks_done_or_claims_fixed():
+    """Unparseable config.yaml: the operator's file is untouched, 'core' is
+    NOT recorded as done (so the required fixes retry next boot), and no
+    config-file fix is announced as applied."""
+    tmp = Path(tempfile.mkdtemp())
+    orig = (autoconfig._CONFIG, autoconfig._MARKER, autoconfig._merged_env,
+            autoconfig.threading, login._show, login._wait_for_tui)
+    shown = []
+
+    class SyncThread:
+        def __init__(self, target=None, daemon=None, name=None):
+            self._t = target
+
+        def start(self):
+            self._t()
+
+    autoconfig._CONFIG = tmp / "config.yaml"
+    autoconfig._MARKER = tmp / "marker"
+    autoconfig._CONFIG.write_text("streaming: [unclosed")
+    autoconfig._merged_env = lambda: {}
+    autoconfig.threading = types.SimpleNamespace(Thread=SyncThread)
+    login._show, login._wait_for_tui = shown.append, lambda: None
+    try:
+        autoconfig.maybe_autoconfigure()
+        assert autoconfig._CONFIG.read_text() == "streaming: [unclosed"  # never clobbered
+        done = set(autoconfig._MARKER.read_text().split()) if autoconfig._MARKER.exists() else set()
+        assert "core" not in done, done  # retried next boot
+        assert not any("streaming" in s for s in shown), shown  # no false 'fixed' claim
+    finally:
+        (autoconfig._CONFIG, autoconfig._MARKER, autoconfig._merged_env,
+         autoconfig.threading, login._show, login._wait_for_tui) = orig
+
+
 if __name__ == "__main__":
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -1,0 +1,124 @@
+"""Checks for the first-boot self-configuration planner.
+
+autoconfig.py's plan() is pure (dicts in, updates out), so no yaml/network is
+needed. Loaded under a fake parent package (the social_learning loader). Run
+directly:  python3 tests/test_autoconfig.py
+"""
+
+import importlib.util
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    pkg = types.ModuleType("_humalike_test_pkg2")
+    pkg.__path__ = [str(_ROOT)]
+    sys.modules["_humalike_test_pkg2"] = pkg
+
+    def _mod(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        mod.__package__ = "_humalike_test_pkg2"
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    lg = _mod("_humalike_test_pkg2.login", _ROOT / "login.py")
+    ac = _mod("_humalike_test_pkg2.autoconfig", _ROOT / "autoconfig.py")
+    return ac, lg
+
+
+autoconfig, login = _load()
+login.HERMES_ENV = Path(tempfile.mkdtemp()) / ".env"  # never read the real one
+
+_COMPLIANT = {"streaming": False, "group_sessions_per_user": False,
+              "display": {"tool_progress": "off"}}
+
+
+def _plan(cfg=None, env=None, done=None):
+    return autoconfig.plan(cfg or {}, env or {}, done or set())
+
+
+# ── Core config ───────────────────────────────────────────────────────────────
+def test_fresh_install_fixes_all_core_settings():
+    config_updates, env_updates, notes, todos, sections = _plan()
+    assert config_updates == {"streaming": False, "group_sessions_per_user": False,
+                              "display": {"tool_progress": "off"}}, config_updates
+    assert not env_updates and not todos
+    assert sections == ["core"] and notes
+
+
+def test_compliant_config_marks_core_done_without_changes():
+    config_updates, _, notes, _, sections = _plan(cfg=dict(_COMPLIANT))
+    assert not config_updates and not notes
+    assert sections == ["core"]  # recorded so it isn't re-checked every boot
+
+
+def test_core_done_is_skipped_and_display_merge_preserves_keys():
+    config_updates, _, _, _, sections = _plan(cfg=dict(_COMPLIANT), done={"core"})
+    assert not config_updates and not sections
+    config_updates, _, _, _, _ = _plan(cfg={"display": {"theme": "x"}})
+    assert config_updates["display"] == {"theme": "x", "tool_progress": "off"}
+
+
+# ── Platforms ─────────────────────────────────────────────────────────────────
+def test_whatsapp_fills_only_unset_keys():
+    _, env_updates, notes, _, sections = _plan(
+        cfg=dict(_COMPLIANT), done={"core"},
+        env={"WHATSAPP_ENABLED": "true", "WHATSAPP_GROUP_POLICY": "allowlist"})
+    assert env_updates == {"WHATSAPP_ALLOW_ALL_USERS": "true",
+                           "WHATSAPP_REQUIRE_MENTION": "false"}, env_updates
+    assert "whatsapp" in sections and notes
+
+
+def test_whatsapp_not_enabled_or_done_is_skipped():
+    _, env_updates, _, _, sections = _plan(env={"WHATSAPP_ENABLED": "false"}, done={"core"})
+    assert not env_updates and not sections
+    _, env_updates, _, _, sections = _plan(
+        env={"WHATSAPP_ENABLED": "true"}, done={"core", "whatsapp"})
+    assert not env_updates and not sections
+
+
+def test_slack_fills_only_unset_keys():
+    _, env_updates, _, _, sections = _plan(
+        done={"core"},
+        env={"SLACK_APP_TOKEN": "xapp-1", "SLACK_ALLOW_ALL_USERS": "true"})
+    assert env_updates == {"SLACK_REQUIRE_MENTION": "false"}, env_updates
+    assert "slack" in sections
+
+
+def test_telegram_is_prompt_only():
+    _, env_updates, _, todos, sections = _plan(
+        done={"core"}, env={"TELEGRAM_BOT_TOKEN": "123:abc"})
+    assert not env_updates  # never guesses chat ids
+    assert "telegram" in sections
+    assert todos and "BotFather" in todos[0]
+    # chats already configured → nothing to prompt
+    _, _, _, todos, _ = _plan(done={"core"}, env={
+        "TELEGRAM_BOT_TOKEN": "123:abc", "TELEGRAM_GROUP_ALLOWED_CHATS": "-100123"})
+    assert not todos
+
+
+# ── upsert_env (the generic writer autoconfig relies on) ─────────────────────
+def test_upsert_env_updates_many_and_preserves_comments():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / ".env"
+        p.write_text("# keep me\nTELEGRAM_BOT_TOKEN=t\nSLACK_REQUIRE_MENTION=true\n")
+        login.upsert_env(p, {"SLACK_REQUIRE_MENTION": "false", "SLACK_ALLOW_ALL_USERS": "true"})
+        lines = p.read_text().splitlines()
+        assert "# keep me" in lines and "TELEGRAM_BOT_TOKEN=t" in lines
+        assert "SLACK_REQUIRE_MENTION=false" in lines
+        assert "SLACK_ALLOW_ALL_USERS=true" in lines
+        assert "SLACK_REQUIRE_MENTION=true" not in lines
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok {name}")
+    print("all passed")

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -134,6 +134,20 @@ def test_telegram_is_prompt_only():
     assert ("ok", "Telegram") in statuses
 
 
+def test_every_changed_value_reports_old_to_new():
+    """Completeness invariant: a full fresh sweep (all platforms in use,
+    nothing configured) changes 9 values, and EVERY one reports 'old → new'."""
+    config_updates, env_updates, statuses, _, _ = _plan(env={
+        "WHATSAPP_ENABLED": "true", "SLACK_BOT_TOKEN": "xoxb-1",
+        "TELEGRAM_BOT_TOKEN": "123:abc"})
+    fixed = [t for k, t in statuses if k == "fixed"]
+    assert len(fixed) == 9, fixed  # 3 core + 3 whatsapp + 2 slack env + 1 slack cfg
+    assert all(" → " in t for t in fixed), [t for t in fixed if " → " not in t]
+    assert all("(.env)" in t or "(config.yaml)" in t for t in fixed), fixed
+    # and the plan really contains all 9 writes
+    assert len(env_updates) == 5 and len(config_updates) == 4
+
+
 # ── upsert_env (the generic writer autoconfig relies on) ─────────────────────
 def test_upsert_env_updates_many_and_preserves_comments():
     with tempfile.TemporaryDirectory() as d:

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -50,7 +50,8 @@ def test_fresh_install_fixes_all_core_settings():
                               "display": {"tool_progress": "off"}}, config_updates
     assert not env_updates and not todos
     assert sections == ["core"]
-    assert statuses[0][0] == "fixed" and "chat settings" in statuses[0][1]
+    assert len(statuses) == 3 and all(k == "fixed" for k, _ in statuses)
+    assert "streaming: (unset) → false" in statuses[0][1]  # old → new shown
 
 
 def test_compliant_config_verifies_core_without_changes():
@@ -75,7 +76,10 @@ def test_whatsapp_fills_only_unset_keys():
     assert env_updates == {"WHATSAPP_ALLOW_ALL_USERS": "true",
                            "WHATSAPP_REQUIRE_MENTION": "false"}, env_updates
     assert "whatsapp" in sections
-    assert ("fixed", "WhatsApp — respond to everyone, in every group, no @mention") in statuses
+    fixed = [t for k, t in statuses if k == "fixed"]
+    assert any(t.startswith("WHATSAPP_ALLOW_ALL_USERS: (unset) → true") for t in fixed), fixed
+    assert any(t.startswith("WHATSAPP_REQUIRE_MENTION: (unset) → false") for t in fixed), fixed
+    assert not any("GROUP_POLICY" in t for t in fixed)  # preset key untouched
 
 
 def test_whatsapp_already_right_shows_verified():

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -45,34 +45,45 @@ def _plan(cfg=None, env=None, done=None):
 
 # ── Core config ───────────────────────────────────────────────────────────────
 def test_fresh_install_fixes_all_core_settings():
-    config_updates, env_updates, notes, todos, sections = _plan()
+    config_updates, env_updates, statuses, todos, sections = _plan()
     assert config_updates == {"streaming": False, "group_sessions_per_user": False,
                               "display": {"tool_progress": "off"}}, config_updates
     assert not env_updates and not todos
-    assert sections == ["core"] and notes
+    assert sections == ["core"]
+    assert statuses[0][0] == "fixed" and "chat settings" in statuses[0][1]
 
 
-def test_compliant_config_marks_core_done_without_changes():
-    config_updates, _, notes, _, sections = _plan(cfg=dict(_COMPLIANT))
-    assert not config_updates and not notes
+def test_compliant_config_verifies_core_without_changes():
+    config_updates, _, statuses, _, sections = _plan(cfg=dict(_COMPLIANT))
+    assert not config_updates
+    assert statuses == [("ok", "chat settings")]  # granular ✓, not silence
     assert sections == ["core"]  # recorded so it isn't re-checked every boot
 
 
 def test_core_done_is_skipped_and_display_merge_preserves_keys():
-    config_updates, _, _, _, sections = _plan(cfg=dict(_COMPLIANT), done={"core"})
-    assert not config_updates and not sections
+    config_updates, _, statuses, _, sections = _plan(cfg=dict(_COMPLIANT), done={"core"})
+    assert not config_updates and not statuses and not sections
     config_updates, _, _, _, _ = _plan(cfg={"display": {"theme": "x"}})
     assert config_updates["display"] == {"theme": "x", "tool_progress": "off"}
 
 
 # ── Platforms ─────────────────────────────────────────────────────────────────
 def test_whatsapp_fills_only_unset_keys():
-    _, env_updates, notes, _, sections = _plan(
+    _, env_updates, statuses, _, sections = _plan(
         cfg=dict(_COMPLIANT), done={"core"},
         env={"WHATSAPP_ENABLED": "true", "WHATSAPP_GROUP_POLICY": "allowlist"})
     assert env_updates == {"WHATSAPP_ALLOW_ALL_USERS": "true",
                            "WHATSAPP_REQUIRE_MENTION": "false"}, env_updates
-    assert "whatsapp" in sections and notes
+    assert "whatsapp" in sections
+    assert ("fixed", "WhatsApp — respond to everyone, in every group, no @mention") in statuses
+
+
+def test_whatsapp_already_right_shows_verified():
+    _, env_updates, statuses, _, _ = _plan(done={"core"}, env={
+        "WHATSAPP_ENABLED": "true", "WHATSAPP_ALLOW_ALL_USERS": "true",
+        "WHATSAPP_REQUIRE_MENTION": "false", "WHATSAPP_GROUP_POLICY": "open"})
+    assert not env_updates
+    assert ("ok", "WhatsApp") in statuses
 
 
 def test_whatsapp_not_enabled_or_done_is_skipped():
@@ -84,19 +95,22 @@ def test_whatsapp_not_enabled_or_done_is_skipped():
 
 
 def test_slack_fills_only_unset_keys_and_forces_reply_in_thread_off():
-    config_updates, env_updates, _, _, sections = _plan(
+    config_updates, env_updates, statuses, _, sections = _plan(
         done={"core"},
         env={"SLACK_APP_TOKEN": "xapp-1", "SLACK_ALLOW_ALL_USERS": "true"})
     assert env_updates == {"SLACK_REQUIRE_MENTION": "false"}, env_updates
     assert config_updates == {"slack": {"reply_in_thread": False}}, config_updates
     assert "slack" in sections
+    assert statuses and statuses[-1][0] == "fixed"
 
 
-def test_slack_reply_in_thread_already_off_and_merge_preserves_keys():
-    config_updates, _, _, _, _ = _plan(
+def test_slack_already_right_shows_verified_and_merge_preserves_keys():
+    config_updates, _, statuses, _, _ = _plan(
         done={"core"}, cfg={"slack": {"reply_in_thread": False}},
-        env={"SLACK_BOT_TOKEN": "xoxb-1"})
+        env={"SLACK_BOT_TOKEN": "xoxb-1", "SLACK_ALLOW_ALL_USERS": "true",
+             "SLACK_REQUIRE_MENTION": "false"})
     assert "slack" not in config_updates
+    assert ("ok", "Slack") in statuses
     config_updates, _, _, _, _ = _plan(
         done={"core"}, cfg={"slack": {"require_mention": False}},
         env={"SLACK_BOT_TOKEN": "xoxb-1"})
@@ -104,15 +118,16 @@ def test_slack_reply_in_thread_already_off_and_merge_preserves_keys():
 
 
 def test_telegram_is_prompt_only():
-    _, env_updates, _, todos, sections = _plan(
+    _, env_updates, statuses, todos, sections = _plan(
         done={"core"}, env={"TELEGRAM_BOT_TOKEN": "123:abc"})
     assert not env_updates  # never guesses chat ids
     assert "telegram" in sections
     assert todos and "BotFather" in todos[0]
-    # chats already configured → nothing to prompt
-    _, _, _, todos, _ = _plan(done={"core"}, env={
+    # chats already configured → verified, nothing to prompt
+    _, _, statuses, todos, _ = _plan(done={"core"}, env={
         "TELEGRAM_BOT_TOKEN": "123:abc", "TELEGRAM_GROUP_ALLOWED_CHATS": "-100123"})
     assert not todos
+    assert ("ok", "Telegram") in statuses
 
 
 # ── upsert_env (the generic writer autoconfig relies on) ─────────────────────

--- a/tests/test_autoconfig.py
+++ b/tests/test_autoconfig.py
@@ -83,12 +83,24 @@ def test_whatsapp_not_enabled_or_done_is_skipped():
     assert not env_updates and not sections
 
 
-def test_slack_fills_only_unset_keys():
-    _, env_updates, _, _, sections = _plan(
+def test_slack_fills_only_unset_keys_and_forces_reply_in_thread_off():
+    config_updates, env_updates, _, _, sections = _plan(
         done={"core"},
         env={"SLACK_APP_TOKEN": "xapp-1", "SLACK_ALLOW_ALL_USERS": "true"})
     assert env_updates == {"SLACK_REQUIRE_MENTION": "false"}, env_updates
+    assert config_updates == {"slack": {"reply_in_thread": False}}, config_updates
     assert "slack" in sections
+
+
+def test_slack_reply_in_thread_already_off_and_merge_preserves_keys():
+    config_updates, _, _, _, _ = _plan(
+        done={"core"}, cfg={"slack": {"reply_in_thread": False}},
+        env={"SLACK_BOT_TOKEN": "xoxb-1"})
+    assert "slack" not in config_updates
+    config_updates, _, _, _, _ = _plan(
+        done={"core"}, cfg={"slack": {"require_mention": False}},
+        env={"SLACK_BOT_TOKEN": "xoxb-1"})
+    assert config_updates["slack"] == {"require_mention": False, "reply_in_thread": False}
 
 
 def test_telegram_is_prompt_only():

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -116,6 +116,12 @@ def test_cfg_env_wins_over_file():
         _clean_env()
 
 
+def test_gateway_key_has_baked_default():
+    """Zero-config: a fresh install must carry the public client identifier."""
+    _clean_env()
+    assert login.gateway_key().startswith("hcg_")
+
+
 # ── login.run: terminal short-circuits (no HTTP reached) ─────────────────────
 def test_run_already_connected_is_success():
     _clean_env()
@@ -128,7 +134,11 @@ def test_run_already_connected_is_success():
 
 def test_run_without_gateway_key_fails_with_manual_hint():
     _clean_env()
-    assert login.run() == 1
+    orig, login.GATEWAY_KEY_DEFAULT = login.GATEWAY_KEY_DEFAULT, ""
+    try:
+        assert login.run() == 1
+    finally:
+        login.GATEWAY_KEY_DEFAULT = orig
 
 
 # ── login.maybe_first_boot_login: the once-marker and the thread ─────────────
@@ -160,8 +170,12 @@ def test_first_boot_login_fires_once():
 def test_first_boot_login_skipped_when_connected_or_unconfigured():
     _clean_env()
     login._MARKER.unlink(missing_ok=True)
-    login.maybe_first_boot_login()  # no gateway key → no-op
-    assert not login._MARKER.exists()
+    orig, login.GATEWAY_KEY_DEFAULT = login.GATEWAY_KEY_DEFAULT, ""
+    try:
+        login.maybe_first_boot_login()  # no gateway key → no-op
+        assert not login._MARKER.exists()
+    finally:
+        login.GATEWAY_KEY_DEFAULT = orig
     os.environ.update(HUMALIKE_CLI_GATEWAY_KEY="gk", HUMALIKE_API_KEY="ak_x")
     try:
         login.maybe_first_boot_login()  # already connected → no-op
@@ -183,7 +197,11 @@ def test_command_already_connected():
 
 def test_command_without_gateway_key_points_to_manual_setup():
     _clean_env()
-    reply = asyncio.run(connect.command(""))
+    orig, login.GATEWAY_KEY_DEFAULT = login.GATEWAY_KEY_DEFAULT, ""
+    try:
+        reply = asyncio.run(connect.command(""))
+    finally:
+        login.GATEWAY_KEY_DEFAULT = orig
     assert "HUMALIKE_API_KEY" in reply, reply  # manual fallback instructions
 
 
@@ -220,14 +238,15 @@ def test_result_messages_offer_retry():
 
 def test_done_message_names_account_and_depends_on_url():
     _clean_env()
-    os.environ["HUMALIKE_API_URL"] = "https://api.humalike.com"
     try:
+        # URL defaults now → active without any env setup
         m = connect._done_message({"account": {"email": "maks@example.com"}})
         assert "maks@example.com" in m and "active" in m
+        os.environ["HUMALIKE_API_URL"] = ""  # explicit opt-out
+        m = connect._done_message({})
+        assert "your account" in m and "HUMALIKE_API_URL" in m
     finally:
         _clean_env()
-    m = connect._done_message({})  # no URL configured, no email returned
-    assert "your account" in m and "HUMALIKE_API_URL" in m
 
 
 if __name__ == "__main__":

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -54,6 +54,9 @@ connect, login = _load()
 # the real .env otherwise, which would make these tests machine-dependent.
 _TMP = Path(tempfile.mkdtemp())
 login.HERMES_ENV = _TMP / ".env"
+# Neutralize the network probe by default so "present key = works" tests never
+# hit the wire; the probe tests set WHOAMI_PATH explicitly.
+login.WHOAMI_PATH = None
 
 
 def _clean_env():
@@ -157,6 +160,34 @@ def test_has_working_key_present_key_without_probe_is_true():
     finally:
         login.WHOAMI_PATH = orig
         _clean_env()
+
+
+def test_has_working_key_probes_when_path_set():
+    """WHOAMI_PATH set: a present key is validated — 200 → works, 401 → dead."""
+    import urllib.error
+    from unittest.mock import patch
+
+    orig_path, login.WHOAMI_PATH = login.WHOAMI_PATH, "/v1/turn-taking/actions/whoami"
+    orig_urlopen = login.urllib.request.urlopen
+
+    class _OK:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    try:
+        with patch.dict(os.environ, {"HUMALIKE_API_KEY": "ak_x"}, clear=False):
+            login._key_ok = None
+            login.urllib.request.urlopen = lambda *a, **k: _OK()      # 2xx
+            assert login.has_working_key() is True
+            login._key_ok = None
+            def _401(*a, **k):
+                raise urllib.error.HTTPError("u", 401, "x", {}, None)
+            login.urllib.request.urlopen = _401
+            assert login.has_working_key() is False                  # dead key → re-login
+    finally:
+        login.urllib.request.urlopen = orig_urlopen
+        login.WHOAMI_PATH = orig_path
+        login._key_ok = None
 
 
 def test_probe_rejects_only_on_401_403():

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -106,6 +106,28 @@ def test_command_single_flight():
     assert "already waiting" in reply, reply
 
 
+def test_command_failure_clears_pending():
+    """The stubbed httpx has no AsyncClient, so the create call fails exactly
+    like a network error — the guard flag must not stay stranded."""
+    _clean_env()
+    os.environ["HUMALIKE_CLI_GATEWAY_KEY"] = "gk"
+    try:
+        reply = asyncio.run(connect.command(""))
+    finally:
+        _clean_env()
+    assert "Couldn't reach Humalike" in reply, reply
+    assert not connect._PENDING.is_set()
+
+
+def test_write_env_tightens_existing_file_mode():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / ".env"
+        p.write_text("X=1\n")
+        p.chmod(0o644)
+        connect._write_env(p, "ak_new")
+        assert (p.stat().st_mode & 0o777) == 0o600
+
+
 # ── Outcome messages ──────────────────────────────────────────────────────────
 def test_result_messages_offer_retry():
     assert "/connect" in connect._result_message("denied")

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -217,6 +217,24 @@ def test_command_single_flight():
     assert "already waiting" in reply, reply
 
 
+def test_command_reshows_pending_first_boot_link():
+    """A TUI banner can hide the first-boot popup's print — /connect must
+    re-show the pending link, not mint a competing session."""
+    _clean_env()
+    login.PENDING_URI = "https://humalike.com/cli/auth?code=hcu_x"
+    try:
+        reply = asyncio.run(connect.command(""))
+    finally:
+        login.PENDING_URI = None
+        _clean_env()
+    assert "hcu_x" in reply, reply
+
+
+def test_poll_session_expired_ttl_is_instant():
+    got = login.poll_session({"expires_in": 0, "device_code": "hcd_x"}, "gk")
+    assert got == {"status": "expired"}, got
+
+
 def test_command_failure_clears_pending():
     """The stubbed httpx has no AsyncClient, so the create call fails exactly
     like a network error — the guard flag must not stay stranded."""

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -54,12 +54,12 @@ connect, login = _load()
 # the real .env otherwise, which would make these tests machine-dependent.
 _TMP = Path(tempfile.mkdtemp())
 login.HERMES_ENV = _TMP / ".env"
-login._MARKER = _TMP / ".login_prompted"
 
 
 def _clean_env():
     for k in ("HUMALIKE_API_KEY", "HUMALIKE_API_URL", "HUMALIKE_CLI_GATEWAY_KEY"):
         os.environ.pop(k, None)
+    login._key_ok = None  # reset the per-process key-validation cache between tests
 
 
 # ── login.write_env_key: the .env upsert ──────────────────────────────────────
@@ -141,10 +141,54 @@ def test_run_without_gateway_key_fails_with_manual_hint():
         login.GATEWAY_KEY_DEFAULT = orig
 
 
-# ── login.maybe_first_boot_login: the once-marker and the thread ─────────────
-def test_first_boot_login_fires_once():
+# ── login.has_working_key: the source of truth ───────────────────────────────
+def test_has_working_key_no_key_is_false():
     _clean_env()
-    os.environ["HUMALIKE_CLI_GATEWAY_KEY"] = "gk"
+    assert login.has_working_key() is False
+
+
+def test_has_working_key_present_key_without_probe_is_true():
+    """WHOAMI_PATH unset → a present key counts as working, no network call."""
+    _clean_env()
+    os.environ["HUMALIKE_API_KEY"] = "ak_x"
+    orig, login.WHOAMI_PATH = login.WHOAMI_PATH, None
+    try:
+        assert login.has_working_key() is True
+    finally:
+        login.WHOAMI_PATH = orig
+        _clean_env()
+
+
+def test_probe_rejects_only_on_401_403():
+    """401/403 → key dead (False); every other error → assume live (True), so an
+    API outage never forces a needless re-login."""
+    import urllib.error
+
+    def _raise(code):
+        def _p(*a, **k):
+            raise urllib.error.HTTPError("u", code, "x", {}, None)
+        return _p
+
+    orig = login.urllib.request.urlopen
+    orig_path, login.WHOAMI_PATH = login.WHOAMI_PATH, "/v1/keys/actions/whoami"
+    try:
+        login.urllib.request.urlopen = _raise(401)
+        assert login._probe("ak_x") is False
+        login.urllib.request.urlopen = _raise(403)
+        assert login._probe("ak_x") is False
+        login.urllib.request.urlopen = _raise(500)
+        assert login._probe("ak_x") is True          # server blip → assume live
+        def _boom(*a, **k):
+            raise OSError("network down")
+        login.urllib.request.urlopen = _boom
+        assert login._probe("ak_x") is True          # unreachable → assume live
+    finally:
+        login.urllib.request.urlopen = orig
+        login.WHOAMI_PATH = orig_path
+
+
+# ── login.maybe_first_boot_login: fires whenever there is no working key ──────
+def _capture_threads():
     started = []
 
     class _T:
@@ -154,33 +198,43 @@ def test_first_boot_login_fires_once():
         def start(self):
             pass
 
-    orig_threading, login.threading = login.threading, types.SimpleNamespace(Thread=_T)
-    login._MARKER.unlink(missing_ok=True)
+    return started, types.SimpleNamespace(Thread=_T)
+
+
+def test_first_boot_login_fires_when_no_working_key():
+    """No marker: with a gateway key and no API key, every call pops the login
+    (self-healing — an unseen/interrupted login re-offers next boot)."""
+    _clean_env()
+    os.environ["HUMALIKE_CLI_GATEWAY_KEY"] = "gk"
+    started, fake = _capture_threads()
+    orig_threading, login.threading = login.threading, fake
     try:
         login.maybe_first_boot_login()
-        assert len(started) == 1 and login._MARKER.exists()
-        login.maybe_first_boot_login()  # marker present → no second popup
-        assert len(started) == 1
+        login._key_ok = None                 # simulate a fresh boot, still keyless
+        login.maybe_first_boot_login()
+        assert len(started) == 2             # fires again — no once-marker
     finally:
         login.threading = orig_threading
-        login._MARKER.unlink(missing_ok=True)
         _clean_env()
 
 
 def test_first_boot_login_skipped_when_connected_or_unconfigured():
     _clean_env()
-    login._MARKER.unlink(missing_ok=True)
+    started, fake = _capture_threads()
+    orig_threading, login.threading = login.threading, fake
     orig, login.GATEWAY_KEY_DEFAULT = login.GATEWAY_KEY_DEFAULT, ""
     try:
-        login.maybe_first_boot_login()  # no gateway key → no-op
-        assert not login._MARKER.exists()
+        login.maybe_first_boot_login()       # no gateway key → no-op
+        assert started == []
     finally:
         login.GATEWAY_KEY_DEFAULT = orig
+    _clean_env()
     os.environ.update(HUMALIKE_CLI_GATEWAY_KEY="gk", HUMALIKE_API_KEY="ak_x")
     try:
-        login.maybe_first_boot_login()  # already connected → no-op
-        assert not login._MARKER.exists()
+        login.maybe_first_boot_login()       # working key present → no-op
+        assert started == []
     finally:
+        login.threading = orig_threading
         _clean_env()
 
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,0 +1,132 @@
+"""Checks for the /connect device-authorization command.
+
+connect.py imports httpx (not installed in this test env) and its siblings via
+relative imports, so we stub httpx and load everything under a fake parent
+package (the social_learning test's loader). Run directly:
+python3 tests/test_connect.py
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+
+    pkg = types.ModuleType("_humalike_test_pkg")
+    pkg.__path__ = [str(_ROOT)]
+    sys.modules["_humalike_test_pkg"] = pkg
+
+    def _mod(name, path, package=None):
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        if package:
+            mod.__package__ = package
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    _mod("_humalike_test_pkg._config", _ROOT / "_config.py")
+
+    tt = types.ModuleType("_humalike_test_pkg.turn_taking")
+    tt.__path__ = [str(_ROOT / "turn_taking")]
+    sys.modules["_humalike_test_pkg.turn_taking"] = tt
+    tt.state = _mod("_humalike_test_pkg.turn_taking.state",
+                    _ROOT / "turn_taking" / "state.py", "_humalike_test_pkg.turn_taking")
+    tt.notify = _mod("_humalike_test_pkg.turn_taking.notify",
+                     _ROOT / "turn_taking" / "notify.py", "_humalike_test_pkg.turn_taking")
+
+    return _mod("_humalike_test_pkg.connect", _ROOT / "connect.py", "_humalike_test_pkg")
+
+
+connect = _load()
+
+
+def _clean_env():
+    for k in ("HUMALIKE_API_KEY", "HUMALIKE_API_URL", "HUMALIKE_CLI_GATEWAY_KEY"):
+        os.environ.pop(k, None)
+
+
+# ── _write_env: the .env upsert ───────────────────────────────────────────────
+def test_write_env_creates_file_with_key():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "sub" / ".env"
+        connect._write_env(p, "ak_new")
+        assert p.read_text() == "HUMALIKE_API_KEY=ak_new\n"
+        assert (p.stat().st_mode & 0o777) == 0o600
+
+
+def test_write_env_replaces_key_and_preserves_other_lines():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / ".env"
+        p.write_text("HUMALIKE_API_URL=https://api.humalike.com\n"
+                     "HUMALIKE_API_KEY=ak_old\n"
+                     "TELEGRAM_BOT_TOKEN=t\n")
+        connect._write_env(p, "ak_new")
+        lines = p.read_text().splitlines()
+        assert "HUMALIKE_API_URL=https://api.humalike.com" in lines
+        assert "TELEGRAM_BOT_TOKEN=t" in lines
+        assert lines.count("HUMALIKE_API_KEY=ak_new") == 1
+        assert not any("ak_old" in ln for ln in lines)
+
+
+# ── command(): the guard rails (no HTTP reached) ──────────────────────────────
+def test_command_already_connected():
+    _clean_env()
+    os.environ["HUMALIKE_API_KEY"] = "ak_x"
+    try:
+        reply = asyncio.run(connect.command(""))
+    finally:
+        _clean_env()
+    assert "Already connected" in reply, reply
+
+
+def test_command_without_gateway_key_points_to_manual_setup():
+    _clean_env()
+    reply = asyncio.run(connect.command(""))
+    assert "HUMALIKE_API_KEY" in reply, reply  # manual fallback instructions
+
+
+def test_command_single_flight():
+    _clean_env()
+    os.environ["HUMALIKE_CLI_GATEWAY_KEY"] = "gk"
+    connect._PENDING.set()
+    try:
+        reply = asyncio.run(connect.command(""))
+    finally:
+        connect._PENDING.clear()
+        _clean_env()
+    assert "already waiting" in reply, reply
+
+
+# ── Outcome messages ──────────────────────────────────────────────────────────
+def test_result_messages_offer_retry():
+    assert "/connect" in connect._result_message("denied")
+    assert "/connect" in connect._result_message("expired")
+
+
+def test_done_message_names_account_and_depends_on_url():
+    _clean_env()
+    os.environ["HUMALIKE_API_URL"] = "https://api.humalike.com"
+    try:
+        m = connect._done_message({"account": {"email": "maks@example.com"}})
+        assert "maks@example.com" in m and "active" in m
+    finally:
+        _clean_env()
+    m = connect._done_message({})  # no URL configured, no email returned
+    assert "your account" in m and "HUMALIKE_API_URL" in m
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok {name}")
+    print("all passed")

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,9 +1,9 @@
-"""Checks for the /connect device-authorization command.
+"""Checks for the /connect device-authorization command and the login module.
 
 connect.py imports httpx (not installed in this test env) and its siblings via
 relative imports, so we stub httpx and load everything under a fake parent
-package (the social_learning test's loader). Run directly:
-python3 tests/test_connect.py
+package (the social_learning test's loader). login.py is stdlib-only. Run
+directly:  python3 tests/test_connect.py
 """
 
 import asyncio
@@ -34,6 +34,7 @@ def _load():
         return mod
 
     _mod("_humalike_test_pkg._config", _ROOT / "_config.py")
+    lg = _mod("_humalike_test_pkg.login", _ROOT / "login.py", "_humalike_test_pkg")
 
     tt = types.ModuleType("_humalike_test_pkg.turn_taking")
     tt.__path__ = [str(_ROOT / "turn_taking")]
@@ -43,10 +44,17 @@ def _load():
     tt.notify = _mod("_humalike_test_pkg.turn_taking.notify",
                      _ROOT / "turn_taking" / "notify.py", "_humalike_test_pkg.turn_taking")
 
-    return _mod("_humalike_test_pkg.connect", _ROOT / "connect.py", "_humalike_test_pkg")
+    cn = _mod("_humalike_test_pkg.connect", _ROOT / "connect.py", "_humalike_test_pkg")
+    return cn, lg
 
 
-connect = _load()
+connect, login = _load()
+
+# Point every ~/.hermes read/write at a scratch dir — gateway_key()/cfg() read
+# the real .env otherwise, which would make these tests machine-dependent.
+_TMP = Path(tempfile.mkdtemp())
+login.HERMES_ENV = _TMP / ".env"
+login._MARKER = _TMP / ".login_prompted"
 
 
 def _clean_env():
@@ -54,11 +62,11 @@ def _clean_env():
         os.environ.pop(k, None)
 
 
-# ── _write_env: the .env upsert ───────────────────────────────────────────────
+# ── login.write_env_key: the .env upsert ──────────────────────────────────────
 def test_write_env_creates_file_with_key():
     with tempfile.TemporaryDirectory() as d:
         p = Path(d) / "sub" / ".env"
-        connect._write_env(p, "ak_new")
+        login.write_env_key(p, "ak_new")
         assert p.read_text() == "HUMALIKE_API_KEY=ak_new\n"
         assert (p.stat().st_mode & 0o777) == 0o600
 
@@ -69,7 +77,7 @@ def test_write_env_replaces_key_and_preserves_other_lines():
         p.write_text("HUMALIKE_API_URL=https://api.humalike.com\n"
                      "HUMALIKE_API_KEY=ak_old\n"
                      "TELEGRAM_BOT_TOKEN=t\n")
-        connect._write_env(p, "ak_new")
+        login.write_env_key(p, "ak_new")
         lines = p.read_text().splitlines()
         assert "HUMALIKE_API_URL=https://api.humalike.com" in lines
         assert "TELEGRAM_BOT_TOKEN=t" in lines
@@ -77,7 +85,92 @@ def test_write_env_replaces_key_and_preserves_other_lines():
         assert not any("ak_old" in ln for ln in lines)
 
 
-# ── command(): the guard rails (no HTTP reached) ──────────────────────────────
+def test_write_env_tightens_existing_file_mode():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / ".env"
+        p.write_text("X=1\n")
+        p.chmod(0o644)
+        login.write_env_key(p, "ak_new")
+        assert (p.stat().st_mode & 0o777) == 0o600
+
+
+# ── login config readers ──────────────────────────────────────────────────────
+def test_read_env_file_parses_and_skips_comments():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / ".env"
+        p.write_text("# comment\nA=1\n\nB = spaced \nnot-a-pair\n")
+        got = login.read_env_file(p)
+        assert got == {"A": "1", "B": "spaced"}, got
+    assert login.read_env_file(Path(d) / "missing") == {}
+
+
+def test_cfg_env_wins_over_file():
+    _clean_env()
+    login.HERMES_ENV.write_text("HUMALIKE_CLI_GATEWAY_KEY=from_file\n")
+    try:
+        assert login.gateway_key() == "from_file"
+        os.environ["HUMALIKE_CLI_GATEWAY_KEY"] = "from_env"
+        assert login.gateway_key() == "from_env"
+    finally:
+        login.HERMES_ENV.unlink()
+        _clean_env()
+
+
+# ── login.run: terminal short-circuits (no HTTP reached) ─────────────────────
+def test_run_already_connected_is_success():
+    _clean_env()
+    os.environ["HUMALIKE_API_KEY"] = "ak_x"
+    try:
+        assert login.run() == 0
+    finally:
+        _clean_env()
+
+
+def test_run_without_gateway_key_fails_with_manual_hint():
+    _clean_env()
+    assert login.run() == 1
+
+
+# ── login.maybe_first_boot_login: the once-marker and the thread ─────────────
+def test_first_boot_login_fires_once():
+    _clean_env()
+    os.environ["HUMALIKE_CLI_GATEWAY_KEY"] = "gk"
+    started = []
+
+    class _T:
+        def __init__(self, **kw):
+            started.append(kw)
+
+        def start(self):
+            pass
+
+    orig_threading, login.threading = login.threading, types.SimpleNamespace(Thread=_T)
+    login._MARKER.unlink(missing_ok=True)
+    try:
+        login.maybe_first_boot_login()
+        assert len(started) == 1 and login._MARKER.exists()
+        login.maybe_first_boot_login()  # marker present → no second popup
+        assert len(started) == 1
+    finally:
+        login.threading = orig_threading
+        login._MARKER.unlink(missing_ok=True)
+        _clean_env()
+
+
+def test_first_boot_login_skipped_when_connected_or_unconfigured():
+    _clean_env()
+    login._MARKER.unlink(missing_ok=True)
+    login.maybe_first_boot_login()  # no gateway key → no-op
+    assert not login._MARKER.exists()
+    os.environ.update(HUMALIKE_CLI_GATEWAY_KEY="gk", HUMALIKE_API_KEY="ak_x")
+    try:
+        login.maybe_first_boot_login()  # already connected → no-op
+        assert not login._MARKER.exists()
+    finally:
+        _clean_env()
+
+
+# ── connect.command(): the guard rails (no HTTP reached) ─────────────────────
 def test_command_already_connected():
     _clean_env()
     os.environ["HUMALIKE_API_KEY"] = "ak_x"
@@ -117,15 +210,6 @@ def test_command_failure_clears_pending():
         _clean_env()
     assert "Couldn't reach Humalike" in reply, reply
     assert not connect._PENDING.is_set()
-
-
-def test_write_env_tightens_existing_file_mode():
-    with tempfile.TemporaryDirectory() as d:
-        p = Path(d) / ".env"
-        p.write_text("X=1\n")
-        p.chmod(0o644)
-        connect._write_env(p, "ak_new")
-        assert (p.stat().st_mode & 0o777) == 0o600
 
 
 # ── Outcome messages ──────────────────────────────────────────────────────────

--- a/tests/test_misconfig.py
+++ b/tests/test_misconfig.py
@@ -1,0 +1,140 @@
+"""Checks for the platform-config warning logic in the plugin root module.
+
+The root __init__.py wires the whole plugin (patching, soul, connect…), so
+every sibling except _config is stubbed and only _resolve,
+_platform_config_problems and the chat-warn marker digest logic are exercised.
+Run directly:  python3 tests/test_misconfig.py
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+
+    pkg = types.ModuleType("_tt_test_pkg")
+    pkg.__path__ = [str(_ROOT)]
+    sys.modules["_tt_test_pkg"] = pkg
+
+    def _stub(name, **attrs):
+        m = types.ModuleType(f"_tt_test_pkg.{name}")
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        sys.modules[f"_tt_test_pkg.{name}"] = m
+        return m
+
+    def noop(*a, **k):
+        return None
+
+    _stub("connect", command=noop)
+    _stub("social_learning", on_pre_llm_call=noop, warm_recent_sessions=noop)
+    _stub("soul", command=noop, maybe_auto_enhance=noop)
+    tt = _stub("turn_taking")
+    tt.__path__ = []
+    tt.hooks = _stub("turn_taking.hooks", on_transform_llm_output=noop)
+    tt.patching = _stub("turn_taking.patching", **{n: (lambda: False) for n in (
+        "_patch__enqueue_text_event", "_patch_merge_pending_message_event",
+        "_patch__poll_messages", "_patch_send", "_patch_slack_handle_message",
+        "_patch_telegram_handle_message", "_patch_telegram_observe_group")})
+    tt.notify = _stub("turn_taking.notify", queue_startup=noop)
+    tt.service = _stub("turn_taking.service", _service_url=lambda: "")
+
+    cfg_spec = importlib.util.spec_from_file_location("_tt_test_pkg._config", _ROOT / "_config.py")
+    cfg = importlib.util.module_from_spec(cfg_spec)
+    sys.modules["_tt_test_pkg._config"] = cfg
+    cfg_spec.loader.exec_module(cfg)
+
+    spec = importlib.util.spec_from_file_location("_tt_test_pkg.plugin_root", _ROOT / "__init__.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_tt_test_pkg.plugin_root"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_MOD = _load()
+
+
+def test_resolve_yaml_first_lists_and_nesting():
+    """yaml wins over env (adapters read config.extra first), lists join to
+    CSV, and platforms.<name>/gateway.platforms.<name> nesting is found."""
+    cfg = {"telegram": {"group_allowed_chats": [-100123, -100456]}}
+    with patch.dict(os.environ, {"TELEGRAM_GROUP_ALLOWED_CHATS": "-1"}, clear=True):
+        got = _MOD._resolve("TELEGRAM_GROUP_ALLOWED_CHATS", cfg, "telegram", "group_allowed_chats")
+    assert got == "-100123,-100456", got
+
+    nested = {"platforms": {"slack": {"require_mention": False}}}
+    with patch.dict(os.environ, {}, clear=True):
+        assert _MOD._resolve("SLACK_REQUIRE_MENTION", nested, "slack", "require_mention") == "False"
+        assert _MOD._resolve("SLACK_REQUIRE_MENTION", None, "slack", "require_mention") is None
+        deep = {"gateway": {"platforms": {"whatsapp": {"group_policy": "open"}}}}
+        assert _MOD._resolve("WHATSAPP_GROUP_POLICY", deep, "whatsapp", "group_policy") == "open"
+
+
+def test_platform_problems_telegram():
+    # Valid yaml list -> no warnings at all.
+    with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "t"}, clear=True):
+        assert _MOD._platform_config_problems({"telegram": {"group_allowed_chats": [-100123]}}) == []
+    # User-level auth alone does NOT enable group observation -> still warns.
+    with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_ALLOWED_USERS": "42",
+                                 "TELEGRAM_GROUP_ALLOWED_USERS": "42"}, clear=True):
+        probs = _MOD._platform_config_problems({})
+        assert len(probs) == 1 and "cannot observe" in probs[0], probs
+    # '*' is matched literally by the host -> flagged as authorizing nothing.
+    with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_GROUP_ALLOWED_CHATS": "*"}, clear=True):
+        assert any("authorizes nothing" in p for p in _MOD._platform_config_problems({}))
+
+
+def test_platform_problems_slack():
+    # 'on' is not host-truthy: flagged as unrecognized AND nobody is authorized.
+    with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "t", "SLACK_ALLOW_ALL_USERS": "on",
+                                 "SLACK_REQUIRE_MENTION": "false"}, clear=True):
+        probs = _MOD._platform_config_problems({})
+        assert any("not a value Hermes accepts" in p for p in probs), probs
+        assert any("no user authorized" in p for p in probs), probs
+    # GATEWAY_ALLOWED_USERS counts as authorization (host honors it).
+    with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "t", "GATEWAY_ALLOWED_USERS": "U1",
+                                 "SLACK_REQUIRE_MENTION": "false"}, clear=True):
+        assert _MOD._platform_config_problems({}) == []
+
+
+def test_platform_problems_whatsapp():
+    # Explicitly disabled (or cloud-only vars) -> platform not in use, no warnings.
+    with patch.dict(os.environ, {"WHATSAPP_ENABLED": "false", "WHATSAPP_CLOUD_ACCESS_TOKEN": "x"}, clear=True):
+        assert _MOD._platform_config_problems({}) == []
+    # Enabled with default policy -> pairing warning.
+    with patch.dict(os.environ, {"WHATSAPP_ENABLED": "true"}, clear=True):
+        assert any("pairing" in p for p in _MOD._platform_config_problems({}))
+
+
+def test_chat_warn_digest_marker():
+    """Marker written only via _mark_chat_warned (delivery), keyed by problem
+    digest: same set silent, changed set warns again; dir auto-created."""
+    import tempfile
+
+    home = Path(tempfile.mkdtemp()) / "hermes-home"  # does not exist yet
+    fake_hc = types.ModuleType("hermes_constants")
+    fake_hc.get_hermes_home = lambda: home
+    sys.modules["hermes_constants"] = fake_hc
+    try:
+        assert _MOD._should_chat_warn("d1") is True
+        _MOD._mark_chat_warned("d1")
+        assert (home / ".turn_taking_config_warned").exists()
+        assert _MOD._should_chat_warn("d1") is False
+        assert _MOD._should_chat_warn("d2") is True
+    finally:
+        sys.modules.pop("hermes_constants", None)
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok  {name}")
+    print("all tests passed")

--- a/tests/test_misconfig.py
+++ b/tests/test_misconfig.py
@@ -98,10 +98,12 @@ def test_platform_problems_slack():
         probs = _MOD._platform_config_problems({})
         assert any("not a value Hermes accepts" in p for p in probs), probs
         assert any("no user authorized" in p for p in probs), probs
-    # GATEWAY_ALLOWED_USERS counts as authorization (host honors it).
+        assert any("reply_in_thread" in p for p in probs), probs  # not set -> warned
+    # GATEWAY_ALLOWED_USERS counts as authorization (host honors it); with
+    # reply_in_thread: false in yaml there is nothing left to warn about.
     with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "t", "GATEWAY_ALLOWED_USERS": "U1",
                                  "SLACK_REQUIRE_MENTION": "false"}, clear=True):
-        assert _MOD._platform_config_problems({}) == []
+        assert _MOD._platform_config_problems({"slack": {"reply_in_thread": False}}) == []
 
 
 def test_platform_problems_whatsapp():

--- a/tests/test_service_keyless.py
+++ b/tests/test_service_keyless.py
@@ -1,0 +1,75 @@
+"""The transport gate: keyless installs must not POST conversation content.
+
+service._post returns None before touching httpx when HUMALIKE_API_KEY is
+unset (the URL now defaults to the public API, so key presence is the real
+on/off switch). httpx is stubbed WITHOUT AsyncClient, so any real send
+attempt raises AttributeError. Run directly:  python3 tests/test_service_keyless.py
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_service():
+    httpx = types.ModuleType("httpx")
+
+    class _Err(Exception):
+        pass
+
+    httpx.HTTPStatusError = _Err
+    httpx.HTTPError = _Err
+    # no AsyncClient on purpose: a real send attempt -> AttributeError
+    sys.modules["httpx"] = httpx
+
+    pkg = types.ModuleType("_hum_svc_pkg")
+    pkg.__path__ = [str(_ROOT)]
+    sys.modules["_hum_svc_pkg"] = pkg
+    tt = types.ModuleType("_hum_svc_pkg.turn_taking")
+    tt.__path__ = [str(_ROOT / "turn_taking")]
+    sys.modules["_hum_svc_pkg.turn_taking"] = tt
+
+    def _mod(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        m = importlib.util.module_from_spec(spec)
+        sys.modules[name] = m
+        spec.loader.exec_module(m)
+        return m
+
+    _mod("_hum_svc_pkg._config", _ROOT / "_config.py")
+    _mod("_hum_svc_pkg.turn_taking.state", _ROOT / "turn_taking" / "state.py")
+    _mod("_hum_svc_pkg.turn_taking.notify", _ROOT / "turn_taking" / "notify.py")
+    return _mod("_hum_svc_pkg.turn_taking.service", _ROOT / "turn_taking" / "service.py")
+
+
+svc = _load_service()
+
+
+def test_keyless_post_is_a_noop():
+    with patch.dict(os.environ, {"HUMALIKE_API_URL": "http://example.test"}, clear=False):
+        os.environ.pop("HUMALIKE_API_KEY", None)
+        assert asyncio.run(svc._post("/x", {"content": "private transcript"})) is None
+
+
+def test_with_key_post_actually_attempts_http():
+    with patch.dict(os.environ, {"HUMALIKE_API_URL": "http://example.test",
+                                 "HUMALIKE_API_KEY": "k"}, clear=False):
+        try:
+            asyncio.run(svc._post("/x", {}))
+        except AttributeError:
+            return  # reached the stubbed-out httpx client — the gate isn't over-blocking
+        raise AssertionError("expected an HTTP attempt when a key is set")
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok  {name}")
+    print("all ok")

--- a/tests/test_social_learning.py
+++ b/tests/test_social_learning.py
@@ -119,7 +119,7 @@ def test_warm_recent_sessions_skips_already_cached():
     sys.modules["hermes_state"] = fake_hs
 
     class SyncThread:
-        def __init__(self, target, args, daemon):
+        def __init__(self, target=None, args=(), daemon=None):
             self._target, self._args = target, args
 
         def start(self):
@@ -143,6 +143,36 @@ def test_warm_recent_sessions_skips_already_cached():
         sys.modules.pop("hermes_state", None)
 
     assert calls == ["warm-1"], calls
+
+
+def test_spawn_refresh_dedups_in_flight():
+    """While a refresh runs for a session, further spawns for it are skipped."""
+    import threading
+
+    calls = []
+    orig_refresh, orig_thread = sl._refresh_card, threading.Thread
+    sl._refresh_card = lambda session_id, history: calls.append(session_id)
+
+    class SyncThread:
+        def __init__(self, target=None, args=(), daemon=None):
+            self._target, self._args = target, args
+
+        def start(self):
+            self._target(*self._args)
+
+    threading.Thread = SyncThread
+    try:
+        sl._REFRESHING.add("dup-1")                      # simulate one in flight
+        assert sl._spawn_refresh("dup-1", []) is False
+        assert calls == []
+        sl._REFRESHING.discard("dup-1")
+        assert sl._spawn_refresh("dup-1", []) is True
+        assert calls == ["dup-1"]
+        assert "dup-1" not in sl._REFRESHING             # cleaned up after the run
+    finally:
+        threading.Thread = orig_thread
+        sl._refresh_card = orig_refresh
+        sl._REFRESHING.discard("dup-1")
 
 
 if __name__ == "__main__":

--- a/tests/test_social_learning.py
+++ b/tests/test_social_learning.py
@@ -151,7 +151,14 @@ def test_spawn_refresh_dedups_in_flight():
 
     calls = []
     orig_refresh, orig_thread = sl._refresh_card, threading.Thread
-    sl._refresh_card = lambda session_id, history: calls.append(session_id)
+
+    def fake_refresh(session_id, history):
+        # The guard must be SET while the refresh runs — catches a regression
+        # that drops _REFRESHING.add (dedup would silently stop deduping).
+        assert session_id in sl._REFRESHING, "in-flight guard not set during refresh"
+        calls.append(session_id)
+
+    sl._refresh_card = fake_refresh
 
     class SyncThread:
         def __init__(self, target=None, args=(), daemon=None):

--- a/tests/test_social_learning.py
+++ b/tests/test_social_learning.py
@@ -91,6 +91,60 @@ def test_cache_survives_reload_from_disk():
         sl._CACHE.pop("restart-test", None)
 
 
+def test_warm_recent_sessions_skips_already_cached():
+    """Fires _refresh_card for uncached recent sessions only, using each
+    session's DB-restored history (not the live pre_llm_call kwarg)."""
+    import tempfile
+    import threading
+
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "state.db").write_text("x")
+
+    fake_hc = types.ModuleType("hermes_constants")
+    fake_hc.get_hermes_home = lambda: tmp
+    sys.modules["hermes_constants"] = fake_hc
+
+    class FakeDB:
+        def __init__(self, db_path, read_only):
+            pass
+
+        def list_sessions_rich(self, limit, order_by_last_active):
+            return [{"id": "warm-1"}, {"id": "warm-2"}]
+
+        def get_messages_as_conversation(self, session_id):
+            return [{"role": "user", "content": "hello there"}]
+
+    fake_hs = types.ModuleType("hermes_state")
+    fake_hs.SessionDB = FakeDB
+    sys.modules["hermes_state"] = fake_hs
+
+    class SyncThread:
+        def __init__(self, target, args, daemon):
+            self._target, self._args = target, args
+
+        def start(self):
+            self._target(*self._args)
+
+    sl._CACHE.pop("warm-1", None)
+    sl._CACHE["warm-2"] = "already cached — should be skipped"
+    calls = []
+    orig_get_url, orig_refresh, orig_thread = sl._get_service_url, sl._refresh_card, threading.Thread
+    sl._get_service_url = lambda: "http://example.test"
+    sl._refresh_card = lambda session_id, history: calls.append(session_id)
+    threading.Thread = SyncThread
+    try:
+        sl.warm_recent_sessions()
+    finally:
+        threading.Thread = orig_thread
+        sl._get_service_url = orig_get_url
+        sl._refresh_card = orig_refresh
+        sl._CACHE.pop("warm-2", None)
+        sys.modules.pop("hermes_constants", None)
+        sys.modules.pop("hermes_state", None)
+
+    assert calls == ["warm-1"], calls
+
+
 if __name__ == "__main__":
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):

--- a/tests/test_social_learning.py
+++ b/tests/test_social_learning.py
@@ -145,6 +145,19 @@ def test_warm_recent_sessions_skips_already_cached():
     assert calls == ["warm-1"], calls
 
 
+def test_service_url_empty_without_api_key():
+    """Keyless: the gate every refresh path checks must be empty — no
+    transcript leaves the machine just to collect a 401."""
+    import os
+    from unittest.mock import patch
+
+    with patch.dict(os.environ, {"HUMALIKE_API_URL": "http://x"}, clear=False):
+        os.environ.pop("HUMALIKE_API_KEY", None)
+        assert sl._get_service_url() == ""
+        os.environ["HUMALIKE_API_KEY"] = "k"
+        assert sl._get_service_url() == "http://x"
+
+
 def test_spawn_refresh_dedups_in_flight():
     """While a refresh runs for a session, further spawns for it are skipped."""
     import threading

--- a/tests/test_soul.py
+++ b/tests/test_soul.py
@@ -47,14 +47,6 @@ def test_persona_text_drops_comments_keeps_heading():
     assert "Hermes Agent Persona" in sent  # heading kept (only the seed check strips it)
 
 
-def test_grounding_validates():
-    os.environ["HERMES_SOUL_GROUNDING"] = "nonsense"
-    assert soul._grounding() == "off"
-    os.environ["HERMES_SOUL_GROUNDING"] = "research"
-    assert soul._grounding() == "research"
-    del os.environ["HERMES_SOUL_GROUNDING"]
-
-
 def test_auto_enhance_default_on_and_disableable():
     os.environ.pop("HERMES_SOUL_AUTO_ENHANCE", None)
     assert soul._auto_enabled() is True  # default on (no config in test env)

--- a/turn_taking/notify.py
+++ b/turn_taking/notify.py
@@ -129,7 +129,8 @@ def queue_startup(text: str, on_delivered=None) -> None:
     (adapters aren't connected yet at register() time). ``on_delivered`` fires
     only after the text actually reached at least one home channel — callers
     use it to record "warned" without losing warnings that never got through."""
-    _pending.append((text, on_delivered))
+    with _LOCK:
+        _pending.append((text, on_delivered))
 
 
 def flush_pending() -> None:
@@ -144,7 +145,13 @@ def flush_pending() -> None:
 
 
 async def _deliver_startup(text: str, cb) -> None:
-    if await _send(text) and cb is not None:
+    if not await _send(text):
+        # Not delivered (no gateway/home channel yet, or the send failed) —
+        # re-queue so a later inbound retries, e.g. once /sethome is run.
+        with _LOCK:
+            _pending.append((text, cb))
+        return
+    if cb is not None:
         try:
             cb()
         except Exception:
@@ -180,10 +187,18 @@ async def _send(text: str) -> bool:
             # turn-taking and drop it as an unsolicited draft.
             orig = state.ORIG_SEND.get(type(adp))
             if orig:
-                await orig(adp, str(home.chat_id), text)
+                res = await orig(adp, str(home.chat_id), text)
             else:
-                await adp.send(str(home.chat_id), text)
-            sent_any = True
+                res = await adp.send(str(home.chat_id), text)
+            # Host adapters don't raise on delivery failure — they return
+            # SendResult(success=False) ("Not connected", flood control…), so
+            # "no exception" is NOT "sent". Default True covers adapters that
+            # return nothing.
+            if getattr(res, "success", True):
+                sent_any = True
+            else:
+                _log.warning("notify: alert to %s home not delivered: %s",
+                             platform, getattr(res, "error", "send failed"))
         except Exception as e:
             _log.warning("notify: alert to %s home failed: %s", platform, e)
     if not sent_any:

--- a/turn_taking/notify.py
+++ b/turn_taking/notify.py
@@ -28,7 +28,7 @@ _COOLDOWN_S = 30 * 60
 _LOCK = threading.Lock()             # alert() is now called from >1 thread
 _last_by_kind: dict[str, float] = {}  # error kind → monotonic ts of last alert
 _active_kinds: set[str] = set()       # kinds currently in the "failing" state
-_pending: list[str] = []              # startup misconfig msgs, flushed on 1st inbound
+_pending: list = []                   # (text, on_delivered) startup msgs, flushed on 1st inbound
 
 WS_LOST = ("⚠️ Humalike realtime connection lost — the bot may go SILENT in "
            "affected chats until the gateway restarts.")
@@ -124,10 +124,12 @@ def recovered() -> None:
         pass
 
 
-def queue_startup(text: str) -> None:
+def queue_startup(text: str, on_delivered=None) -> None:
     """Queue a startup misconfig alert; delivered on the first inbound message
-    (adapters aren't connected yet at register() time)."""
-    _pending.append(text)
+    (adapters aren't connected yet at register() time). ``on_delivered`` fires
+    only after the text actually reached at least one home channel — callers
+    use it to record "warned" without losing warnings that never got through."""
+    _pending.append((text, on_delivered))
 
 
 def flush_pending() -> None:
@@ -137,8 +139,16 @@ def flush_pending() -> None:
         return
     with _LOCK:
         msgs, _pending[:] = list(_pending), []
-    for m in msgs:
-        _schedule(lambda m=m: _send(m))
+    for m, cb in msgs:
+        _schedule(lambda m=m, cb=cb: _deliver_startup(m, cb))
+
+
+async def _deliver_startup(text: str, cb) -> None:
+    if await _send(text) and cb is not None:
+        try:
+            cb()
+        except Exception:
+            _log.warning("notify: on_delivered callback failed", exc_info=True)
 
 
 # ── Delivery ──────────────────────────────────────────────────────────────────
@@ -155,10 +165,10 @@ def _gateway() -> Any:
     return None
 
 
-async def _send(text: str) -> None:
+async def _send(text: str) -> bool:
     gw = _gateway()
     if gw is None:
-        return  # no adapter/gateway seen yet — nothing to send through (caller logged)
+        return False  # no adapter/gateway seen yet — nothing to send through (caller logged)
     # Every configured home channel — one platform failing must not skip the rest.
     sent_any = False
     for platform, adp in list(getattr(gw, "adapters", {}).items()):
@@ -178,3 +188,4 @@ async def _send(text: str) -> None:
             _log.warning("notify: alert to %s home failed: %s", platform, e)
     if not sent_any:
         _log.info("notify: no home channel set — run /sethome to get alerts in chat")
+    return sent_any

--- a/turn_taking/patching.py
+++ b/turn_taking/patching.py
@@ -343,6 +343,8 @@ async def _handle_observed_group(self: Any, event: Any, replay: Callable[[], Any
         state.LOOP = asyncio.get_running_loop()
     except RuntimeError:
         pass
+    state.LAST_ADAPTER = self  # notify.py fallback when no thread ever opened
+    notify.flush_pending()  # observe-only deployments never reach _handle_inbound
     _patch__reply_anchor_for_event(self)
     message_id = str(getattr(event, "message_id", "") or "")
     source = event.source

--- a/turn_taking/patching.py
+++ b/turn_taking/patching.py
@@ -152,6 +152,7 @@ async def _handle_inbound(self: Any, event: Any) -> None:
     notify.flush_pending()  # deliver any queued startup misconfig alerts (cheap no-op after 1st)
     _patch__reply_anchor_for_event(self)  # bind per-turn raw message_id (queue-robust)
     source = event.source
+    state.LAST_CHAT_ID = str(getattr(source, "chat_id", "") or "")  # /connect reply route
     message_id = str(getattr(event, "message_id", "") or "")
     _log.info("tt inbound: chat=%s sender=%s mid=%s text=%r",
               getattr(source, "chat_id", None), getattr(source, "user_name", None),

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -67,6 +67,11 @@ async def _post(path: str, body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     base = _service_url()
     if not base:
         return None
+    if not _api_key():
+        # Keyless: never ship conversation content off-machine just to collect
+        # a 401. Fail-open exactly like an unreachable service; /connect puts
+        # the key live in-process, so this un-gates without a restart.
+        return None
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             r = await client.post(base + path, json=body, headers=_headers())

--- a/turn_taking/state.py
+++ b/turn_taking/state.py
@@ -40,6 +40,11 @@ ORIG_HANDLE: Dict[type, Callable] = {}
 # ever opened, but an alert still needs a live adapter to reach the gateway).
 LAST_ADAPTER: Any = None
 
+# The most recent inbound chat_id, set next to LAST_ADAPTER. Together they name
+# "the chat that just messaged us" — connect.py captures the pair at /connect
+# time to route the approval confirmation back to the invoking chat.
+LAST_CHAT_ID: str = ""
+
 # ── Session → thread map: one thread per conversation ─────────────────────────
 SESSIONS: Dict[str, str] = {}  # Hermes session_id → turn-taking thread_id
 OPEN_LOCK = asyncio.Lock()     # serializes thread-opens (rare) so a burst can't double-open


### PR DESCRIPTION
Adds a `/connect` chat command implementing the RFC 8628 device-authorization lane that svc-keys ships (`cli_create` / `cli_poll` on the `/v1/keys` edge route).

## Flow

1. User sends the bot `/connect` (any platform; works before any key is configured).
2. Bot replies with the `verification_uri` login link. The user opens it in a browser on **any** device — phone included, so SSH/VM/Docker gateways never need a display.
3. A daemon thread polls `cli_poll`; on `authorized` the freshly minted `ak_…` key goes live in-process immediately (`os.environ` — every Humalike call reads it fresh, no restart) and is upserted into `~/.hermes/.env` (created 0600).
4. The outcome (✅ connected as <email> / ❌ denied / ⌛ expired) is confirmed in the invoking chat, via the route captured at command time (`state.LAST_ADAPTER`/`LAST_CHAT_ID`, new) and the genuine pre-patch `send`.

The boot-time missing-key warning now nudges toward `/connect` instead of only manual key pasting; README + install skill updated accordingly.

## Hardening (from a multi-agent adversarial review of this diff)

- Reply route captured **before** any await — a concurrent chat's inbound during the `cli_create` round-trip used to be able to mis-route the confirmation.
- Single-flight guard set before the await (no check-then-act gap); cleared on the failure path.
- `.env` created 0600 from the first byte; pre-existing files tightened.
- When no deliverable route exists (e.g. `HUMALIKE_API_URL` unset → inbound patches inactive), the reply no longer promises an in-chat confirmation; the outcome is logged for headless installs.
- HTTP rejection of `cli_create` reported distinctly from network failure.

## Known limitations (deliberate)

- **Group hijack surface**: the link binds whoever approves it in the browser — inherent to broadcasting a device-flow link. The reply warns to prefer a DM, the install skill says DM explicitly, and the confirmation names the linked account email for detection. Server-side consent shows hostname/OS.
- On a Telegram forum-group the confirmation lands in General (sent without topic metadata).
- One in-flight link at a time per gateway (10-min TTL bounds the wait).

## Follow-ups needed to go live

1. **Bake the public client identifier**: `_GATEWAY_KEY_DEFAULT` is empty — until the published value lands, `/connect` requires `HUMALIKE_CLI_GATEWAY_KEY` in the env (documented in README/skill; without it the command degrades to manual-key instructions).
2. The `humalike.com/cli/auth` consent page still needs to be built in humalike-v1 (`apps/web`) — backend + tests exist, the page does not.

## Notes

- Stacked on #10 (`config-warnings-and-card-warmup`); merge that first. This branch also carries 9cae27d (review fixes for #10 done in a parallel session).
- Tests: `python3 tests/test_connect.py` (9 checks). `test_soul.py`/`test_to_messages.py` failures are pre-existing on the base branch (missing httpx in env / stale test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-start autoconfiguration and device-login account linking, including an in-chat **/connect** flow (no restart required).
  * Improved startup diagnostics (misconfiguration reporting) and warmed voice-card refresh for recent sessions.
* **Bug Fixes**
  * Prevented outbound API calls when no API key is set.
  * Improved reliability of startup warning delivery, retry behavior, and connect follow-up routing.
* **Documentation**
  * Reworked onboarding/setup guides for the **humalike** plugin and updated login/config flow.
* **Breaking Change**
  * Removed SOUL “grounding” from **/soul enhance**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->