### PR TITLE
Strip native memory's style capture (the voice card owns style)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,8 @@ together:
       build), patching (the gateway monkeypatches), hooks (the plugin hooks)
   - ``social_learning/``  the per-conversation voice card (pre_llm_call hook)
   - ``soul/``             the SOUL.md persona feature (the /soul command)
+  - ``native_memory``     strips native memory's *style* capture (the voice card
+                          above owns style) so the two layers don't double-record
 
 This module only registers the plugin's command, hooks, and patches.
 """
@@ -19,7 +21,7 @@ import logging
 import os
 from pathlib import Path
 
-from . import _config, autoconfig, connect, login, social_learning, soul
+from . import _config, autoconfig, connect, login, native_memory, social_learning, soul
 from .turn_taking.hooks import on_transform_llm_output
 from .turn_taking.patching import (
     _patch__enqueue_text_event,
@@ -281,6 +283,13 @@ def register(ctx) -> None:
         social_learning.warm_recent_sessions()
     except Exception as e:
         _log.warning("turn-taking: social-learning warm-up skipped: %s", e)
+    # Native memory owns durable FACTS; the voice card above owns STYLE. Stop
+    # native memory from also capturing style so the two layers don't
+    # double-record it (and a stale snapshot can't fight the live card).
+    try:
+        native_memory.strip_native_style_capture()
+    except Exception as e:
+        _log.warning("turn-taking: native-memory style strip skipped: %s", e)
     if not login.has_working_key():
         # No usable API key → turn-taking stays a no-op this boot (the login
         # popped above drives connection; /soul and the social-learning hook,

--- a/native_memory.py
+++ b/native_memory.py
@@ -1,0 +1,119 @@
+"""Stop native memory from capturing conversational *style*.
+
+Hermes's built-in memory tool is told to record how the user/group communicates
+(tone, formality, verbosity, the group's norms). The Humalike plugin already
+owns that layer: the per-conversation voice card in ``social_learning/`` learns
+the live style and injects it into every reply. Letting native memory ALSO
+persist style double-captures it — and a stale saved snapshot then fights the
+live card. So at register time we surgically remove the style clause from the
+memory tool and forbid re-capturing it, leaving durable FACT memory (name, role,
+timezone, stated preferences) untouched.
+
+Two edits, both at load time, no hooks:
+  1. memory tool schema description (``tools.memory_tool`` via the registry) —
+     read live each request, so mutating it in place takes effect.
+  2. ``MEMORY_GUIDANCE`` — imported by-name into ``agent.system_prompt`` and
+     ``agent.prompt_builder``, so we patch the binding the prompt builder reads.
+
+Best-effort and idempotent; never raises. No-op on a Hermes without these
+internals (the imports simply fail and each edit reports False). The host
+imports are deferred into the functions so importing this module never needs
+the Hermes runtime — the register-time call is the only place it touches it.
+
+Run the checks directly:  python3 tests/test_native_memory.py
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+_log = logging.getLogger(__name__)
+
+# Explicit prohibition injected into both the tool schema and the guidance.
+# The marker lets us stay idempotent (don't append twice on re-register).
+_PROHIBITION = (
+    "NEVER save how the user or group communicates or behaves socially. This is "
+    "owned by a separate social-learning layer; recording any of it in memory is "
+    "forbidden. Specifically do NOT save:\n"
+    "  - STYLE: tone, register/formality (terse, warm, formal, casual), message "
+    "length/verbosity, emoji/slang/punctuation/capitalization habits, formatting, "
+    "or how people phrase or word things.\n"
+    "  - NORMS: the group's unwritten social rules and conversational conventions "
+    "— when to speak up or stay quiet, how much detail is wanted, what gets mocked "
+    "or corrected, inside jokes, greetings/sign-offs, response timing/rhythm, or "
+    "any 'how this group/conversation operates' behavioral pattern.\n"
+    "Save only durable FACTS (name, role, timezone, stated preferences about the "
+    "task itself, environment details) — never the manner of communication."
+)
+
+
+def _strip_schema_style() -> bool:
+    """Remove the 'communication style' clause from the live memory tool schema
+    AND append an explicit do-not-save prohibition. Returns True if it changed
+    anything."""
+    try:
+        import tools.memory_tool  # noqa: F401 — ensure the tool is registered
+        from tools.registry import registry
+
+        entry = registry.get_entry("memory")
+        schema = getattr(entry, "schema", None) if entry else None
+        if not isinstance(schema, dict):
+            return False
+        desc = schema.get("description", "")
+        changed = False
+        if "communication style" in desc:
+            desc = desc.replace(", communication style", "")
+            changed = True
+        if _PROHIBITION not in desc:
+            # Tack the prohibition onto the existing SKIP guidance.
+            desc = desc.rstrip() + "\n\n" + _PROHIBITION
+            changed = True
+        if changed:
+            schema["description"] = desc
+        return changed
+    except Exception as exc:
+        _log.warning("turn-taking: native-memory schema patch failed: %s", exc)
+        return False
+
+
+def _strip_guidance_style() -> bool:
+    """Remove the style-flavored example from MEMORY_GUIDANCE in the modules that
+    actually read it, and append the prohibition. Returns True if it patched a
+    module."""
+    patched = False
+    # The 'concise responses' example is the only style-ish line in the guidance.
+    style_example = (
+        "'User prefers concise responses' ✓ — 'Always respond concisely' ✗. "
+    )
+    try:
+        import agent.prompt_builder as pb
+        import agent.system_prompt as sp
+
+        for mod in (pb, sp):
+            text = getattr(mod, "MEMORY_GUIDANCE", None)
+            if not isinstance(text, str):
+                continue
+            new = text
+            if style_example in new:
+                new = new.replace(style_example, "")
+            if _PROHIBITION not in new:
+                new = new.rstrip() + "\n" + _PROHIBITION
+            if new != text:
+                setattr(mod, "MEMORY_GUIDANCE", new)
+                patched = True
+    except Exception as exc:
+        _log.warning("turn-taking: native-memory guidance patch failed: %s", exc)
+    return patched
+
+
+def strip_native_style_capture() -> tuple[bool, bool]:
+    """Apply both edits at register time. Returns ``(schema_patched,
+    guidance_patched)`` for logging/tests; never raises."""
+    schema = _strip_schema_style()
+    guidance = _strip_guidance_style()
+    _log.info(
+        "turn-taking: native-memory style capture stripped (schema=%s, guidance=%s)",
+        schema, guidance,
+    )
+    return schema, guidance

--- a/tests/test_native_memory.py
+++ b/tests/test_native_memory.py
@@ -1,0 +1,122 @@
+"""Checks for native_memory — stripping native memory's *style* capture.
+
+native_memory.py defers its Hermes imports (``tools.*``, ``agent.*``) into the
+two strip functions, so we load the module plainly and stub those host modules
+in ``sys.modules`` before calling. Stdlib-only, no network. Run directly:
+    python3 tests/test_native_memory.py
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+# The style-flavored example native_memory removes — must match the literal in
+# _strip_guidance_style() so the seeded guidance actually contains it.
+_STYLE_EXAMPLE = "'User prefers concise responses' ✓ — 'Always respond concisely' ✗. "
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("native_memory", _ROOT / "native_memory.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _install_tools(schema_desc):
+    """Fake ``tools.memory_tool`` + ``tools.registry`` with a live memory schema
+    dict. Returns the schema dict so the caller can read it back after a patch."""
+    schema = {"description": schema_desc}
+    entry = types.SimpleNamespace(schema=schema)
+    registry = types.SimpleNamespace(
+        get_entry=lambda name: entry if name == "memory" else None
+    )
+    tools = types.ModuleType("tools")
+    tools_registry = types.ModuleType("tools.registry")
+    tools_registry.registry = registry
+    tools.registry = tools_registry
+    sys.modules["tools"] = tools
+    sys.modules["tools.registry"] = tools_registry
+    sys.modules["tools.memory_tool"] = types.ModuleType("tools.memory_tool")
+    return schema
+
+
+def _install_agent(guidance):
+    """Fake ``agent.prompt_builder`` + ``agent.system_prompt`` carrying
+    MEMORY_GUIDANCE. Returns (pb, sp) so the caller can read them back."""
+    pb = types.ModuleType("agent.prompt_builder")
+    sp = types.ModuleType("agent.system_prompt")
+    pb.MEMORY_GUIDANCE = guidance
+    sp.MEMORY_GUIDANCE = guidance
+    agent = types.ModuleType("agent")
+    agent.prompt_builder = pb
+    agent.system_prompt = sp
+    sys.modules["agent"] = agent
+    sys.modules["agent.prompt_builder"] = pb
+    sys.modules["agent.system_prompt"] = sp
+    return pb, sp
+
+
+def _clear_host():
+    for name in ("tools", "tools.registry", "tools.memory_tool",
+                 "agent", "agent.prompt_builder", "agent.system_prompt"):
+        sys.modules.pop(name, None)
+
+
+def test_schema_strip_and_idempotent():
+    nm = _load()
+    schema = _install_tools(
+        "Save facts about the user: name, role, preferences, communication style, environment."
+    )
+    assert nm._strip_schema_style() is True
+    desc = schema["description"]
+    assert "communication style" not in desc, "style clause should be gone"
+    assert nm._PROHIBITION in desc, "prohibition should be appended"
+    # Idempotent: a second call changes nothing and never double-appends.
+    assert nm._strip_schema_style() is False
+    assert schema["description"].count(nm._PROHIBITION) == 1
+    _clear_host()
+
+
+def test_guidance_strip_both_modules_and_idempotent():
+    nm = _load()
+    guidance = "Memory guidance.\nExample: " + _STYLE_EXAMPLE + "\nMore text."
+    pb, sp = _install_agent(guidance)
+    assert nm._strip_guidance_style() is True
+    for mod in (pb, sp):
+        assert _STYLE_EXAMPLE not in mod.MEMORY_GUIDANCE, "style example should be gone"
+        assert nm._PROHIBITION in mod.MEMORY_GUIDANCE, "prohibition should be appended"
+    # Idempotent across re-register.
+    assert nm._strip_guidance_style() is False
+    assert pb.MEMORY_GUIDANCE.count(nm._PROHIBITION) == 1
+    _clear_host()
+
+
+def test_noop_without_host_never_raises():
+    nm = _load()
+    _clear_host()  # no tools.* / agent.* installed → imports fail inside the fns
+    assert nm._strip_schema_style() is False
+    assert nm._strip_guidance_style() is False
+    # Public entry stays quiet and returns the pair.
+    assert nm.strip_native_style_capture() == (False, False)
+
+
+def test_facts_survive():
+    """The point of the plugin: FACT wording is untouched, only STYLE is cut."""
+    nm = _load()
+    schema = _install_tools("Save name, role, timezone, preferences, communication style.")
+    nm._strip_schema_style()
+    desc = schema["description"]
+    for fact in ("name", "role", "timezone", "preferences"):
+        assert fact in desc, f"fact '{fact}' must survive"
+    _clear_host()
+
+
+if __name__ == "__main__":
+    test_schema_strip_and_idempotent()
+    test_guidance_strip_both_modules_and_idempotent()
+    test_noop_without_host_never_raises()
+    test_facts_survive()
+    print("native_memory: all checks passed ✓")


### PR DESCRIPTION
## Why

The plugin's social-learning **voice card** (`social_learning/`) already learns each conversation's *style* and injects it live into every reply. But Hermes's **native memory tool** is separately instructed to record how the user/group communicates (tone, formality, verbosity, group norms). That double-captures style — and a stale saved snapshot then fights the live card.

## What

New module `native_memory.py`, called once from `register()` (best-effort, alongside the voice-card registration). At load time it:

1. Removes the `communication style` clause from the **live memory tool schema** (`tools.memory_tool` via the registry — read fresh each request, so an in-place mutation takes effect).
2. Strips the style-flavored example from **`MEMORY_GUIDANCE`** in `agent.system_prompt` and `agent.prompt_builder` (the bindings the prompt builder actually reads).
3. Appends an explicit do-not-save **prohibition** so the model won't re-capture style.

Durable **FACT** memory (name, role, timezone, stated task preferences) is untouched — only the *manner of communication* is cut.

**Safety:** best-effort and idempotent (a marker prevents double-append on re-register), never raises, and a clean no-op on a Hermes build without those internals (the deferred host imports just fail and each edit reports `False`).

## Test

`tests/test_native_memory.py` (stdlib-only, stubs the host `tools.*`/`agent.*` modules; run directly with `python3 tests/test_native_memory.py`):
- schema clause removed + prohibition appended, idempotent on re-call
- guidance patched in both modules, idempotent
- FACT wording survives
- no-op / never raises when host internals are absent

Full existing suite still passes (the two unrelated pre-existing failures — `test_soul` needs `httpx`, `test_to_messages` references a since-moved `_to_messages` — reproduce on `main` and are untouched here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for keeping conversation-style details out of native memory capture.
  * The app now applies this protection during startup and continues safely if it can’t be applied.

* **Bug Fixes**
  * Reduced duplicate recording of style-related content in memory and guidance text.
  * Preserved factual content while removing style-specific examples from stored guidance.

* **Tests**
  * Added coverage for style removal, repeatable behavior, and safe no-op behavior when required components are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->