### PR TITLE
feat: per-reply pacing from config (turn_taking.pacing rides on respond)

### DIFF
--- a/tests/test_service_pacing.py
+++ b/tests/test_service_pacing.py
@@ -1,8 +1,8 @@
 """``turn_taking.pacing`` in config.yaml rides on every respond as ``pacing``.
 
 The service's PacingOverrides (reading_delay_ms, typing_wpm, max_typing_ms)
-paces this agent's replies only; unset config omits the field so the service
-defaults apply. Run directly:  python3 tests/test_service_pacing.py
+paces this agent's replies only; unset config falls back to the plugin's own
+default (_DEFAULT_PACING). Run directly:  python3 tests/test_service_pacing.py
 """
 
 import asyncio
@@ -65,19 +65,19 @@ def _respond_body(config_text):
 
 
 def test_configured_pacing_rides_on_respond():
-    body = _respond_body("turn_taking:\n  pacing:\n    typing_wpm: 75\n")
-    assert body["pacing"] == {"typing_wpm": 75}
+    body = _respond_body("turn_taking:\n  pacing:\n    typing_wpm: 40\n    reading_delay_ms: 0\n")
+    assert body["pacing"] == {"typing_wpm": 40, "reading_delay_ms": 0}
     assert body["turn_epoch"] == 3  # rest of the body untouched
 
 
-def test_no_pacing_config_omits_the_field():
+def test_no_pacing_config_falls_back_to_plugin_default():
     body = _respond_body("streaming: false\n")
-    assert "pacing" not in body
+    assert body["pacing"] == svc._DEFAULT_PACING == {"typing_wpm": 75}
 
 
-def test_empty_or_garbage_pacing_is_omitted():
-    assert "pacing" not in _respond_body("turn_taking:\n  pacing: {}\n")
-    assert "pacing" not in _respond_body("turn_taking:\n  pacing: fast\n")
+def test_empty_or_garbage_pacing_falls_back_to_default():
+    assert _respond_body("turn_taking:\n  pacing: {}\n")["pacing"] == svc._DEFAULT_PACING
+    assert _respond_body("turn_taking:\n  pacing: fast\n")["pacing"] == svc._DEFAULT_PACING
 
 
 if __name__ == "__main__":

--- a/tests/test_service_pacing.py
+++ b/tests/test_service_pacing.py
@@ -1,0 +1,88 @@
+"""``turn_taking.pacing`` in config.yaml rides on every respond as ``pacing``.
+
+The service's PacingOverrides (reading_delay_ms, typing_wpm, max_typing_ms)
+paces this agent's replies only; unset config omits the field so the service
+defaults apply. Run directly:  python3 tests/test_service_pacing.py
+"""
+
+import asyncio
+import importlib.util
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_service():
+    sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+    httpx = sys.modules["httpx"]
+    if not hasattr(httpx, "HTTPError"):
+        httpx.HTTPStatusError = type("HTTPStatusError", (Exception,), {})
+        httpx.HTTPError = type("HTTPError", (Exception,), {})
+
+    pkg = types.ModuleType("_hum_pacing_pkg")
+    pkg.__path__ = [str(_ROOT)]
+    sys.modules["_hum_pacing_pkg"] = pkg
+    tt = types.ModuleType("_hum_pacing_pkg.turn_taking")
+    tt.__path__ = [str(_ROOT / "turn_taking")]
+    sys.modules["_hum_pacing_pkg.turn_taking"] = tt
+
+    def _mod(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        m = importlib.util.module_from_spec(spec)
+        sys.modules[name] = m
+        spec.loader.exec_module(m)
+        return m
+
+    _mod("_hum_pacing_pkg._config", _ROOT / "_config.py")
+    _mod("_hum_pacing_pkg.turn_taking.state", _ROOT / "turn_taking" / "state.py")
+    _mod("_hum_pacing_pkg.turn_taking.notify", _ROOT / "turn_taking" / "notify.py")
+    return _mod("_hum_pacing_pkg.turn_taking.service", _ROOT / "turn_taking" / "service.py")
+
+
+svc = _load_service()
+
+
+def _respond_body(config_text):
+    """Run respond() against a temp config.yaml; return the posted body."""
+    tmp = Path(tempfile.mkdtemp()) / "config.yaml"
+    tmp.write_text(config_text)
+    captured = {}
+
+    async def fake_post(path, body):
+        captured[path] = body
+        return {"scheduled": True}
+
+    orig_cfg, orig_post = svc._HERMES_CONFIG, svc._post
+    svc._HERMES_CONFIG, svc._post = tmp, fake_post
+    try:
+        asyncio.run(svc.respond("tid", "draft", 3))
+    finally:
+        svc._HERMES_CONFIG, svc._post = orig_cfg, orig_post
+    return captured[svc.RESPOND_PATH]
+
+
+def test_configured_pacing_rides_on_respond():
+    body = _respond_body("turn_taking:\n  pacing:\n    typing_wpm: 75\n")
+    assert body["pacing"] == {"typing_wpm": 75}
+    assert body["turn_epoch"] == 3  # rest of the body untouched
+
+
+def test_no_pacing_config_omits_the_field():
+    body = _respond_body("streaming: false\n")
+    assert "pacing" not in body
+
+
+def test_empty_or_garbage_pacing_is_omitted():
+    assert "pacing" not in _respond_body("turn_taking:\n  pacing: {}\n")
+    assert "pacing" not in _respond_body("turn_taking:\n  pacing: fast\n")
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok  {name}")
+    print("all ok")

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -56,20 +56,29 @@ def _headers() -> Dict[str, str]:
     return {"Authorization": f"Bearer {_api_key()}", "Content-Type": "application/json"}
 
 
-def _pacing() -> Optional[Dict[str, Any]]:
-    """Per-reply pacing overrides from ``turn_taking.pacing`` in config.yaml,
-    passed verbatim to the service (its ``PacingOverrides``: reading_delay_ms,
-    typing_wpm, max_typing_ms — each optional, absent = service default).
-    Unset/invalid → None (omit the field entirely). Read per call like SOUL.md,
-    so a config edit paces the very next reply, no restart."""
+# The plugin's own pacing default: half the service's stock 150 wpm — the
+# humanlike product wants a slower, more deliberate typist out of the box.
+# Only typing_wpm is pinned; reading delay and the per-message cap stay with
+# the service (it fills every field the request leaves unset).
+_DEFAULT_PACING: Dict[str, Any] = {"typing_wpm": 75}
+
+
+def _pacing() -> Dict[str, Any]:
+    """Per-reply pacing sent on every respond (svc ``PacingOverrides``:
+    reading_delay_ms, typing_wpm, max_typing_ms — each optional, absent =
+    service default). ``turn_taking.pacing`` in config.yaml wins when set to a
+    non-empty mapping; otherwise ``_DEFAULT_PACING``. Read per call like
+    SOUL.md, so a config edit paces the very next reply, no restart."""
     try:
         import yaml
 
         cfg = yaml.safe_load(_HERMES_CONFIG.read_text()) or {}
         pacing = (cfg.get("turn_taking") or {}).get("pacing")
-        return dict(pacing) if isinstance(pacing, dict) and pacing else None
+        if isinstance(pacing, dict) and pacing:
+            return dict(pacing)
     except Exception:
-        return None
+        pass
+    return dict(_DEFAULT_PACING)
 
 
 # ── Transport ─────────────────────────────────────────────────────────────────
@@ -147,9 +156,7 @@ async def respond(
         body["system_prompt"] = system_prompt[:_SYSTEM_PROMPT_CAP]
     if metadata:
         body["metadata"] = metadata
-    pacing = _pacing()
-    if pacing:
-        body["pacing"] = pacing
+    body["pacing"] = _pacing()
     return await _post(RESPOND_PATH, body)
 
 

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -56,6 +56,22 @@ def _headers() -> Dict[str, str]:
     return {"Authorization": f"Bearer {_api_key()}", "Content-Type": "application/json"}
 
 
+def _pacing() -> Optional[Dict[str, Any]]:
+    """Per-reply pacing overrides from ``turn_taking.pacing`` in config.yaml,
+    passed verbatim to the service (its ``PacingOverrides``: reading_delay_ms,
+    typing_wpm, max_typing_ms — each optional, absent = service default).
+    Unset/invalid → None (omit the field entirely). Read per call like SOUL.md,
+    so a config edit paces the very next reply, no restart."""
+    try:
+        import yaml
+
+        cfg = yaml.safe_load(_HERMES_CONFIG.read_text()) or {}
+        pacing = (cfg.get("turn_taking") or {}).get("pacing")
+        return dict(pacing) if isinstance(pacing, dict) and pacing else None
+    except Exception:
+        return None
+
+
 # ── Transport ─────────────────────────────────────────────────────────────────
 async def _post(path: str, body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """POST ``body`` to ``path`` and return parsed JSON, or None on any failure.
@@ -131,6 +147,9 @@ async def respond(
         body["system_prompt"] = system_prompt[:_SYSTEM_PROMPT_CAP]
     if metadata:
         body["metadata"] = metadata
+    pacing = _pacing()
+    if pacing:
+        body["pacing"] = pacing
     return await _post(RESPOND_PATH, body)
 
 


### PR DESCRIPTION
## What

Every `respond` call now carries a `pacing` object (the service's `PacingOverrides`: `reading_delay_ms` / `typing_wpm` / `max_typing_ms`, each field optional — the service fills whatever is left unset).

- `turn_taking.pacing` in config.yaml wins when set to a non-empty mapping (sent verbatim).
- Otherwise the plugin's own default applies: `{typing_wpm: 75}` — half the service's stock 150 wpm, the humanlike out-of-the-box pace.

Config is re-read per call (same pattern as SOUL.md), so a pacing edit takes effect on the very next reply with no gateway restart.

## Test plan

`python3 tests/test_service_pacing.py` — configured pacing rides verbatim, unset config falls back to `_DEFAULT_PACING`, empty/garbage config falls back too. `tests/test_service_keyless.py` still green.

Note: the first commit re-applies `6cb6f0b` (reverted from main in `6b8c325` to go through review here); the second adds the plugin default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-reply pacing support in service requests, driven by local configuration when available.
  * Service requests now include a `pacing` field on every reply, using configured values when valid.

* **Bug Fixes**
  * Invalid, empty, or missing pacing configuration is handled safely by falling back to the service default pacing (rather than sending incomplete or no pacing).

* **Tests**
  * Added coverage to verify pacing behavior across configured, missing, empty, and invalid cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->