### PR TITLE
feat(turn-taking): pass the bot's display name to respond (agent_name)

### DIFF
--- a/tests/test_agent_name.py
+++ b/tests/test_agent_name.py
@@ -77,10 +77,12 @@ def test_respond_caps_agent_name_to_contract_limit():
     assert len(_respond_body(agent_name="x" * 300)["agent_name"]) == 255
 
 
-def test_agent_name_env_override_and_config_fallback(tmp_path=None):
+def test_agent_name_env_config_then_hardcoded_default(tmp_path=None):
     # core._agent_name reads HERMES_AGENT_NAME first, then agent.name in
-    # ~/.hermes/config.yaml. Exercise both without loading all of core.py's
-    # imports: point its _HERMES_CONFIG at a temp file.
+    # ~/.hermes/config.yaml, then falls back to the hardcoded "Hermes" (the
+    # product name — every un-renamed install gets the fix with zero config).
+    # Exercise all three without loading all of core.py's imports: point its
+    # _HERMES_CONFIG at a temp file.
     import tempfile
 
     core = _load_core()
@@ -89,12 +91,14 @@ def test_agent_name_env_override_and_config_fallback(tmp_path=None):
     os.environ.pop("HERMES_AGENT_NAME", None)
     with tempfile.TemporaryDirectory() as d:
         cfg = Path(d) / "config.yaml"
-        cfg.write_text("agent:\n  name: Hermes\n")
+        cfg.write_text("agent:\n  name: Viktor\n")
         with patch.object(core, "_HERMES_CONFIG", cfg):
-            assert core._agent_name() == "Hermes"
+            assert core._agent_name() == "Viktor"
         cfg.write_text("agent: {}\n")
         with patch.object(core, "_HERMES_CONFIG", cfg):
-            assert core._agent_name() is None
+            assert core._agent_name() == "Hermes"
+    with patch.object(core, "_HERMES_CONFIG", Path("/nonexistent/config.yaml")):
+        assert core._agent_name() == "Hermes"
 
 
 def _load_core():

--- a/tests/test_agent_name.py
+++ b/tests/test_agent_name.py
@@ -1,0 +1,136 @@
+"""`agent_name` on the respond wire call + the `_agent_name()` resolver.
+
+The service uses agent_name to label the bot's own lines in the theory-of-mind
+transcript (mismatched identity made small models reply in the third person /
+to themselves). Loads service.py standalone with stubbed httpx, same pattern as
+test_service_keyless. Run directly:  python3 tests/test_agent_name.py
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_service():
+    httpx = types.ModuleType("httpx")
+
+    class _Err(Exception):
+        pass
+
+    httpx.HTTPStatusError = _Err
+    httpx.HTTPError = _Err
+    sys.modules["httpx"] = httpx
+
+    pkg = types.ModuleType("_hum_an_pkg")
+    pkg.__path__ = [str(_ROOT)]
+    sys.modules["_hum_an_pkg"] = pkg
+    tt = types.ModuleType("_hum_an_pkg.turn_taking")
+    tt.__path__ = [str(_ROOT / "turn_taking")]
+    sys.modules["_hum_an_pkg.turn_taking"] = tt
+
+    def _mod(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        m = importlib.util.module_from_spec(spec)
+        sys.modules[name] = m
+        spec.loader.exec_module(m)
+        return m
+
+    _mod("_hum_an_pkg._config", _ROOT / "_config.py")
+    _mod("_hum_an_pkg.turn_taking.state", _ROOT / "turn_taking" / "state.py")
+    _mod("_hum_an_pkg.turn_taking.notify", _ROOT / "turn_taking" / "notify.py")
+    return _mod("_hum_an_pkg.turn_taking.service", _ROOT / "turn_taking" / "service.py")
+
+
+svc = _load_service()
+
+
+def _respond_body(**kwargs):
+    """Call svc.respond with _post recorded; return the wire body."""
+    sent = {}
+
+    async def _post(path, body):
+        sent["path"], sent["body"] = path, body
+        return {"scheduled": []}
+
+    with patch.object(svc, "_post", _post):
+        asyncio.run(svc.respond("tid", "draft", 3, **kwargs))
+    return sent["body"]
+
+
+def test_respond_sends_agent_name():
+    body = _respond_body(agent_name="Hermes")
+    assert body["agent_name"] == "Hermes"
+
+
+def test_respond_omits_agent_name_when_unset():
+    assert "agent_name" not in _respond_body()
+    assert "agent_name" not in _respond_body(agent_name="")
+
+
+def test_respond_caps_agent_name_to_contract_limit():
+    assert len(_respond_body(agent_name="x" * 300)["agent_name"]) == 255
+
+
+def test_agent_name_env_override_and_config_fallback(tmp_path=None):
+    # core._agent_name reads HERMES_AGENT_NAME first, then agent.name in
+    # ~/.hermes/config.yaml. Exercise both without loading all of core.py's
+    # imports: point its _HERMES_CONFIG at a temp file.
+    import tempfile
+
+    core = _load_core()
+    with patch.dict(os.environ, {"HERMES_AGENT_NAME": "EnvBot"}, clear=False):
+        assert core._agent_name() == "EnvBot"
+    os.environ.pop("HERMES_AGENT_NAME", None)
+    with tempfile.TemporaryDirectory() as d:
+        cfg = Path(d) / "config.yaml"
+        cfg.write_text("agent:\n  name: Hermes\n")
+        with patch.object(core, "_HERMES_CONFIG", cfg):
+            assert core._agent_name() == "Hermes"
+        cfg.write_text("agent: {}\n")
+        with patch.object(core, "_HERMES_CONFIG", cfg):
+            assert core._agent_name() is None
+
+
+def _load_core():
+    """Load core.py with its sibling imports stubbed (delivery, social_learning)."""
+    def _stub(name, **attrs):
+        m = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        sys.modules[name] = m
+        return m
+
+    _stub("_hum_an_pkg.social_learning", get_card=lambda sid: None)
+    _stub("_hum_an_pkg.turn_taking.delivery", _ensure_thread=None, _chat_for_session=None)
+    if "yaml" not in sys.modules:
+        # PyYAML ships with the gateway but not necessarily this test env; the
+        # tests only feed `agent:\n  name: X` / `agent: {}`, so a two-line
+        # parser is enough.
+        def _safe_load(text):
+            lines = [l for l in text.splitlines() if l.strip()]
+            if lines == ["agent: {}"]:
+                return {"agent": {}}
+            return {"agent": {"name": lines[1].split(":", 1)[1].strip()}}
+
+        _stub("yaml", safe_load=_safe_load)
+    spec = importlib.util.spec_from_file_location(
+        "_hum_an_pkg.turn_taking.core", _ROOT / "turn_taking" / "core.py"
+    )
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["_hum_an_pkg.turn_taking.core"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok  {name}")
+    print("all ok")

--- a/turn_taking/core.py
+++ b/turn_taking/core.py
@@ -73,6 +73,26 @@ def _build_system_prompt_for_turn_taking(adapter: Any = None, session_id: Option
         return None
 
 
+def _agent_name() -> Optional[str]:
+    """The bot's display name (``agent.name`` in ~/.hermes/config.yaml, or
+    ``HERMES_AGENT_NAME``), passed to the service so the theory-of-mind call
+    labels the bot's own transcript lines with its real name instead of the
+    internal ``agent`` label. When the persona says "You are Hermes" but the
+    transcript says ``agent``, the small ToM model can lose track of which
+    speaker it is (third-person replies, replying to itself). None when unset
+    (service default, current behaviour)."""
+    env = os.getenv("HERMES_AGENT_NAME", "").strip()
+    if env:
+        return env
+    try:
+        import yaml
+
+        cfg = yaml.safe_load(_HERMES_CONFIG.read_text()) or {}
+        return str((cfg.get("agent") or {}).get("name", "")).strip() or None
+    except Exception:
+        return None
+
+
 def _delivery_meta(event: Any) -> Dict[str, str]:
     """Opaque per-turn delivery hints to round-trip through respond → bubble.
 
@@ -141,7 +161,7 @@ async def _respond(
         return False  # this session never decided speak
     _log.info("tt respond: session=%s tid=%s epoch=%s → naturalizing | %r",
               session_id, tid, epoch, (draft or "").strip()[:60])
-    res = await respond(tid, draft, epoch, system_prompt, metadata)
+    res = await respond(tid, draft, epoch, system_prompt, metadata, agent_name=_agent_name())
     if not res or res.get("superseded"):
         _log.info("tt respond: session=%s → DROPPED (superseded=%s / no response)",
                   session_id, bool(res and res.get("superseded")))

--- a/turn_taking/core.py
+++ b/turn_taking/core.py
@@ -73,14 +73,18 @@ def _build_system_prompt_for_turn_taking(adapter: Any = None, session_id: Option
         return None
 
 
-def _agent_name() -> Optional[str]:
-    """The bot's display name (``agent.name`` in ~/.hermes/config.yaml, or
-    ``HERMES_AGENT_NAME``), passed to the service so the theory-of-mind call
-    labels the bot's own transcript lines with its real name instead of the
-    internal ``agent`` label. When the persona says "You are Hermes" but the
-    transcript says ``agent``, the small ToM model can lose track of which
-    speaker it is (third-person replies, replying to itself). None when unset
-    (service default, current behaviour)."""
+DEFAULT_AGENT_NAME = "Hermes"
+
+
+def _agent_name() -> str:
+    """The bot's display name (``HERMES_AGENT_NAME``, then ``agent.name`` in
+    ~/.hermes/config.yaml, then "Hermes"), passed to the service so the
+    theory-of-mind call labels the bot's own transcript lines with its real
+    name instead of the internal ``agent`` label. When the persona says "You
+    are Hermes" but the transcript says ``agent``, the small ToM model can
+    lose track of which speaker it is (third-person replies, replying to
+    itself). The default matches the product name — right for every install
+    that didn't rename the bot; set agent.name when yours did."""
     env = os.getenv("HERMES_AGENT_NAME", "").strip()
     if env:
         return env
@@ -88,9 +92,9 @@ def _agent_name() -> Optional[str]:
         import yaml
 
         cfg = yaml.safe_load(_HERMES_CONFIG.read_text()) or {}
-        return str((cfg.get("agent") or {}).get("name", "")).strip() or None
+        return str((cfg.get("agent") or {}).get("name", "")).strip() or DEFAULT_AGENT_NAME
     except Exception:
-        return None
+        return DEFAULT_AGENT_NAME
 
 
 def _delivery_meta(event: Any) -> Dict[str, str]:

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -144,18 +144,27 @@ async def respond(
     turn_epoch: int,
     system_prompt: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = None,
+    agent_name: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Naturalize a draft (epoch required, fail-closed). Returns {scheduled, superseded}.
 
     ``metadata`` is an opaque per-turn bag the service echoes verbatim on every
     delivered bubble frame (svc contract ``RespondRequest.metadata``, cap 4 KB) —
     used here to carry the forum-topic id to ``_forward``.
+
+    ``agent_name`` is the bot's display name (svc contract
+    ``RespondRequest.agent_name``, cap 255): the service uses it to label the
+    bot's own lines in the theory-of-mind transcript so the model doesn't
+    confuse the bot with an interlocutor (third-person replies, replying to
+    itself). Omitted → the service's generic internal label.
     """
     body: Dict[str, Any] = {"thread_id": thread_id, "content": content, "turn_epoch": turn_epoch}
     if system_prompt:
         body["system_prompt"] = system_prompt[:_SYSTEM_PROMPT_CAP]
     if metadata:
         body["metadata"] = metadata
+    if agent_name:
+        body["agent_name"] = agent_name[:255]
     body["pacing"] = _pacing()
     return await _post(RESPOND_PATH, body)
 


### PR DESCRIPTION
Companion to the svc-turn-taking `RespondRequest.agent_name` change (Humalike/humalike-v1#210).

The service's theory-of-mind call frames its prompt around a named agent and labels the bot's own transcript lines; with the internal `agent` label but a persona saying "You are Hermes", the small ToM model loses track of which speaker it is — third-person replies, or replying to its own last message.

This sends the bot's display name on every `respond`, resolved as: `HERMES_AGENT_NAME` env → `agent.name` in `~/.hermes/config.yaml` → hardcoded `"Hermes"`. Every un-renamed install gets the fix with zero config; renamed bots set `agent.name`. Safe to ship before or after the service PR (the service ignores unknown behaviour changes gracefully — an `agent_name` sent to an old service is rejected only once that deploy validates it, and the plugin fails open).

Tests: `python3 tests/test_agent_name.py` (wire body include/omit/cap + resolver env/config/default). `tests/test_to_messages.py` fails on a clean tree too — pre-existing, unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including an agent display name in turn-taking responses.
  * The response now uses a configured name (or environment override) with a default when none is set.

* **Bug Fixes**
  * Blank or missing names are omitted/safely handled.
  * Agent names are capped to a maximum length to keep request payloads valid.

* **Tests**
  * Added unit tests covering name precedence (env vs config vs default) and response payload inclusion/truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->