### PR TITLE
turn-taking: resolve @mentions so the agent knows who was mentioned (self vs others), all platforms

### DIFF
--- a/turn_taking/patching.py
+++ b/turn_taking/patching.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import sys
 from typing import Any, Callable
 
@@ -18,6 +19,63 @@ from .core import _inbound_gate, _build_system_prompt_for_turn_taking, _decide, 
 from .service import _to_messages
 
 _log = logging.getLogger(__name__)
+
+_MENTION_RE = re.compile(r"<@([A-Z0-9]+)>")
+
+
+async def _annotate_mentions(adapter: Any, event: Any) -> None:
+    """Make mentions in the inbound text legible to the turn-taking service, so the
+    agent can tell WHO was mentioned and whether it was itself or someone else. The
+    bot's own mention becomes ``@you``; other people keep an identifiable handle.
+    The result is stashed on ``event._tt_content`` (read by ``service._to_messages``)
+    so only the service's view changes, never Hermes's dispatch or history.
+
+    Platform-independent by reusing each adapter's OWN mention machinery, all
+    duck-typed and fail-open (a mention-less message or an adapter missing these
+    hooks is left untouched):
+
+    * Slack — ``<@ID>`` tokens: the bot's ``_bot_user_id`` → ``@you``, others
+      resolved to ``@DisplayName`` via ``_resolve_user_name``.
+    * Telegram/WhatsApp (and any adapter exposing ``_mention_patterns``) — the
+      compiled self-mention patterns ARE "how this bot is addressed", so
+      ``pattern.sub("@you", …)`` marks the bot's own mention; other participants
+      already appear as ``@handle`` / ``@number`` and pass through.
+    """
+    text = getattr(event, "text", "") or ""
+    if not text:
+        return
+    original = text
+    # Slack: <@id> tokens (bot id + async display-name resolver).
+    bot_id = getattr(adapter, "_bot_user_id", None)
+    resolver = getattr(adapter, "_resolve_user_name", None)
+    ids = _MENTION_RE.findall(text)
+    if ids and (bot_id is not None or resolver is not None):
+        chat_id = str(getattr(getattr(event, "source", None), "chat_id", "") or "")
+        for uid in dict.fromkeys(ids):  # unique, order-preserving
+            if bot_id and uid == bot_id:
+                repl = "@you"
+            elif resolver is not None:
+                try:
+                    name = await resolver(uid, chat_id)
+                except Exception as e:
+                    _log.debug("tt: mention resolve failed for %s: %s", uid, e)
+                    continue  # leave this token as-is on lookup failure
+                if not name:
+                    continue  # empty display name → leave the raw token, not a bare "@"
+                repl = "@" + name
+            else:
+                continue
+            text = text.replace(f"<@{uid}>", repl)
+    # Telegram/WhatsApp/…: mark the bot's OWN mention as @you via its self-mention
+    # patterns. Other participants' @handles/@numbers are already legible.
+    for pat in getattr(adapter, "_mention_patterns", None) or []:
+        try:
+            text = pat.sub("@you", text)
+        except Exception as e:
+            _log.debug("tt: mention pattern sub failed: %s", e)
+    if text != original:
+        event._tt_content = text
+
 
 _reply_anchor_patched = False  # idempotency for _patch__reply_anchor_for_event
 _merge_patched = False  # idempotency for _patch_merge_pending_message_event
@@ -157,6 +215,10 @@ async def _handle_inbound(self: Any, event: Any) -> None:
     _log.info("tt inbound: chat=%s sender=%s mid=%s text=%r",
               getattr(source, "chat_id", None), getattr(source, "user_name", None),
               message_id, (getattr(event, "text", "") or "")[:50])
+    try:
+        await _annotate_mentions(self, event)  # resolve <@id> → @you / @Name for the service
+    except Exception as e:
+        _log.debug("tt: mention annotate skipped: %s", e)
     store = getattr(self, "_session_store", None)
     try:
         if store is not None:

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -251,7 +251,9 @@ def _to_messages(events: list) -> list[Dict[str, Any]]:
     """
     out: list[Dict[str, Any]] = []
     for ev in events:
-        content = (getattr(ev, "text", "") or "").strip()
+        # ``_tt_content`` (set by patching._annotate_mentions) has <@id> mentions
+        # resolved to @you / @Name; fall back to the raw text when it's absent.
+        content = (getattr(ev, "_tt_content", None) or getattr(ev, "text", "") or "").strip()
         mtype = getattr(getattr(ev, "message_type", None), "value", "") or ""
         # WhatsApp only emits "text" or a media type (commands arrive as text), so
         # anything else — or any attached media — marks this as a media message.


### PR DESCRIPTION
## Goal (from the user's perspective)

The agent should know **who was mentioned in a message — and whether it was itself or someone else** — on every platform the plugin supports (Slack, Telegram, WhatsApp).

Today it can't: the turn-taking `decide`/`respond` service only receives `{sender, content}`, and `content` carries raw, platform-specific mention tokens (`<@U0ABC>`, `@username`, `@15551234567`) that the model can't attribute — it doesn't know which id/handle is *itself*, so a direct mention often still yields `stay_silent`, and other participants are opaque.

## Change

Resolve mentions **before** the text reaches the service, reusing each adapter's **own** mention machinery (no new per-platform parsing, no core/server changes):

- **Slack / Discord** — `<@ID>` tokens: the bot's `_bot_user_id` → `@you`, others → `@DisplayName` via the adapter's `_resolve_user_name` (cached → `users.info`).
- **Telegram / WhatsApp** (any adapter exposing `_mention_patterns`) — those compiled patterns *are* "how this bot is addressed", so `pattern.sub("@you", …)` marks the bot's own mention; other participants already read as `@handle` / `@number` and pass through.

Result the decider/agent now sees, uniformly:

```
Mateusz: @you can you check the repo with @Alice?
```

so it can tell it was addressed (the decide prompt speaks "when addressed") and who else was named.

The resolved text is stashed on `event._tt_content` and read by `service._to_messages`, so **only the service's view changes** — Hermes's dispatched prompt and stored history are untouched. Everything is duck-typed and fail-open: a mention-less message, or an adapter missing these hooks, is left unchanged.

## Scope / honest caveats

- **"Was it me?"** → works on all three supported platforms.
- **Resolving *other* people to names** → full on Slack; Telegram mentions are already `@username` (legible); WhatsApp non-name mentions stay `@number` (the adapter doesn't cheaply expose a number→name map). Number-based WhatsApp self-mentions are caught only if covered by the configured `_mention_patterns`.
- Slack path uses `_bot_user_id` (`xoxb-` bot token required; a user token would misbind identity — Hermes already warns on that at connect).

## Testing

- `py_compile` clean on both files.
- Offline unit check of both paths: `@hermesbot … @alice` → `@you … @alice`; `<@U0BOT> … <@U0ALICE>` → `@you … @Alice`.
- Ran live on a Dockerized Hermes (`@hermes2`, Slack): inbound mentions reach the decide service with `<@bot>`→`@you` and other users resolved to names; dispatched agent prompt and history unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced inbound mention rewriting: recognized `<`@ID`>` mentions are converted into readable handles for downstream processing.
  * Mentions of the bot now display as `@you`, while other mentions resolve to the referenced person’s name.

* **Bug Fixes**
  * If mention parsing or name resolution isn’t available, message content remains unchanged.
  * Failures during mention processing no longer block inbound message handling; normal flow continues.
  * Updated message text generation to use the rewritten mention content when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->