### PR TITLE
feat(turn-taking): use Humalike social memory

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,7 +22,7 @@ import os
 from pathlib import Path
 
 from . import _config, autoconfig, connect, login, native_memory, social_learning, soul
-from .turn_taking.hooks import on_transform_llm_output
+from .turn_taking.hooks import on_pre_llm_call, on_transform_llm_output
 from .turn_taking.patching import (
     _patch__enqueue_text_event,
     _patch_merge_pending_message_event,
@@ -279,6 +279,14 @@ def register(ctx) -> None:
         _log.info("turn-taking: registered social-learning pre_llm_call hook")
     except Exception as e:
         _log.warning("turn-taking: could not register social-learning hook: %s", e)
+    # Social memory: inject what the agent remembers about the people here (the
+    # context recalled at decide) into the reply draft. Multiple pre_llm_call
+    # hooks are supported — both this and the voice card above run.
+    try:
+        ctx.register_hook("pre_llm_call", on_pre_llm_call)
+        _log.info("turn-taking: registered social-memory pre_llm_call hook")
+    except Exception as e:
+        _log.warning("turn-taking: could not register social-memory hook: %s", e)
     try:
         social_learning.warm_recent_sessions()
     except Exception as e:

--- a/tests/test_social_memory.py
+++ b/tests/test_social_memory.py
@@ -1,0 +1,126 @@
+"""Social-memory integration: open_thread enables it, and the context recalled
+at decide is injected into the reply draft (pre_llm_call) and folded into the
+respond system_prompt.
+
+turn_taking imports httpx and its relative siblings, so we stub httpx and load
+the modules under a fake package (like test_service_pacing), stubbing core +
+delivery so hooks loads without the full chain. Run directly:
+  python3 tests/test_social_memory.py
+"""
+
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_PKG = "_hum_sm_pkg"
+
+
+def _load():
+    sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+    httpx = sys.modules["httpx"]
+    if not hasattr(httpx, "HTTPError"):
+        httpx.HTTPStatusError = type("HTTPStatusError", (Exception,), {})
+        httpx.HTTPError = type("HTTPError", (Exception,), {})
+
+    pkg = types.ModuleType(_PKG)
+    pkg.__path__ = [str(_ROOT)]
+    sys.modules[_PKG] = pkg
+    tt = types.ModuleType(_PKG + ".turn_taking")
+    tt.__path__ = [str(_ROOT / "turn_taking")]
+    sys.modules[_PKG + ".turn_taking"] = tt
+
+    def _mod(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        m = importlib.util.module_from_spec(spec)
+        sys.modules[name] = m
+        spec.loader.exec_module(m)
+        return m
+
+    _mod(_PKG + "._config", _ROOT / "_config.py")
+    state = _mod(_PKG + ".turn_taking.state", _ROOT / "turn_taking" / "state.py")
+    _mod(_PKG + ".turn_taking.notify", _ROOT / "turn_taking" / "notify.py")
+    service = _mod(_PKG + ".turn_taking.service", _ROOT / "turn_taking" / "service.py")
+
+    # Stub core + delivery so hooks imports resolve without loading the chain.
+    core = types.ModuleType(_PKG + ".turn_taking.core")
+    core._build_system_prompt_for_turn_taking = lambda adapter, sid: "PERSONA"
+
+    async def _respond(*a, **k):
+        return True
+
+    core._respond = _respond
+    sys.modules[_PKG + ".turn_taking.core"] = core
+    delivery = types.ModuleType(_PKG + ".turn_taking.delivery")
+    delivery._chat_for_session = lambda sid: None
+    sys.modules[_PKG + ".turn_taking.delivery"] = delivery
+
+    hooks = _mod(_PKG + ".turn_taking.hooks", _ROOT / "turn_taking" / "hooks.py")
+    return state, service, hooks
+
+
+STATE, SVC, HOOKS = _load()
+
+
+def _open_body(**env):
+    """Call open_thread with env overrides; return the posted body."""
+    captured = {}
+
+    async def fake_post(path, body):
+        captured["body"] = body
+        return {"thread": {"id": "t1"}}
+
+    orig_post = SVC._post
+    SVC._post = fake_post
+    old = {k: os.environ.get(k) for k in env}
+    os.environ.update(env)
+    try:
+        asyncio.run(SVC.open_thread("t1"))
+    finally:
+        SVC._post = orig_post
+        for k, v in old.items():
+            os.environ.pop(k, None) if v is None else os.environ.__setitem__(k, v)
+    return captured["body"]
+
+
+def test_open_thread_enables_social_memory_with_bank_id():
+    body = _open_body(HUMALIKE_MEMORY_BANK_ID="agent-42")
+    assert body["thread_id"] == "t1"
+    assert body["integrations"]["social_memory"]["memory_bank_id"] == "agent-42"
+
+
+def test_bank_id_override_is_capped():
+    body = _open_body(HUMALIKE_MEMORY_BANK_ID="x" * 300)
+    assert len(body["integrations"]["social_memory"]["memory_bank_id"]) == 255
+
+
+def test_pre_llm_call_injects_memory_only_when_present():
+    STATE.MEMORY_BY_SESSION.clear()
+    assert HOOKS.on_pre_llm_call(session_id="s1") is None  # no memory -> no inject
+    STATE.MEMORY_BY_SESSION["s1"] = "alice has churned before; wants terse replies"
+    out = HOOKS.on_pre_llm_call(session_id="s1")
+    assert out and "alice has churned before" in out["context"]
+    STATE.MEMORY_BY_SESSION["s2"] = ""  # empty -> no inject
+    assert HOOKS.on_pre_llm_call(session_id="s2") is None
+    assert HOOKS.on_pre_llm_call(session_id="") is None  # no session -> no inject
+
+
+def test_with_memory_folds_into_respond_system_prompt():
+    STATE.MEMORY_BY_SESSION.clear()
+    assert HOOKS._with_memory("PERSONA", "s1") == "PERSONA"  # no memory -> unchanged
+    STATE.MEMORY_BY_SESSION["s1"] = "bob prefers technical detail"
+    out = HOOKS._with_memory("PERSONA", "s1")
+    assert out.startswith("PERSONA") and "bob prefers technical detail" in out
+    # No base prompt -> just the memory block.
+    assert HOOKS._with_memory(None, "s1").endswith("bob prefers technical detail")
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"ok  {name}")
+    print("all ok")

--- a/turn_taking/core.py
+++ b/turn_taking/core.py
@@ -134,6 +134,10 @@ async def _decide(
         return None
     decision = res.get("decision")
     epoch = res.get("turn_epoch")
+    # Reuse this one recall for the reply: the draft (pre_llm_call hook) and the
+    # respond system_prompt both read it. "" when memory is off/empty or the API
+    # returns no recalled_context — then injection simply no-ops.
+    state.MEMORY_BY_SESSION[session_id] = res.get("recalled_context") or ""
     if decision == "speak" and message_id:
         # ponytail: no message_id → can't correlate at respond time, so don't stash;
         # the turn then degrades to a plain (un-naturalized) reply rather than risk a

--- a/turn_taking/core.py
+++ b/turn_taking/core.py
@@ -128,9 +128,11 @@ async def _decide(
     """
     tid = await _ensure_thread(session_id, adapter, chat_id)
     if not tid:
+        state.MEMORY_BY_SESSION.pop(session_id, None)  # no stale recall into fail-open replies
         return None
     res = await submit_messages(tid, messages, system_prompt)
     if not res:
+        state.MEMORY_BY_SESSION.pop(session_id, None)
         return None
     decision = res.get("decision")
     epoch = res.get("turn_epoch")

--- a/turn_taking/hooks.py
+++ b/turn_taking/hooks.py
@@ -37,6 +37,36 @@ def _current_message_id() -> str:
     return state.TT_MID_CTX.get("") or ""
 
 
+# Label for the recalled memory wherever it is injected — the reply draft (the
+# pre_llm_call hook, into Hermes's user message) and the respond system_prompt.
+_MEMORY_LABEL = "What you know about the people here (from memory):"
+
+
+def on_pre_llm_call(**kwargs):
+    """pre_llm_call hook: inject the social-memory context recalled at decide into
+    the reply draft, so what the agent knows about these people shapes WHAT it
+    writes. Mirrors the social-learning voice card. Returns None (nothing
+    injected) when the session has no memory — memory off, empty, or an API that
+    does not return ``recalled_context``.
+    """
+    session_id = kwargs.get("session_id") or ""
+    mem = state.MEMORY_BY_SESSION.get(session_id) if session_id else ""
+    if not mem:
+        return None
+    return {"context": f"{_MEMORY_LABEL}\n{mem}"}
+
+
+def _with_memory(system_prompt, session_id):
+    """Fold the turn's recalled memory into the respond system_prompt, so the
+    reply-refinement steps see it too — the same single recall, no second lookup.
+    Unchanged when there is no memory."""
+    mem = state.MEMORY_BY_SESSION.get(session_id) if session_id else ""
+    if not mem:
+        return system_prompt
+    block = f"{_MEMORY_LABEL}\n{mem}"
+    return f"{system_prompt}\n\n{block}" if system_prompt else block
+
+
 def on_transform_llm_output(response_text=None, session_id=None, **kwargs):
     """Fired once per turn with the agent's FINAL answer (after the tool loop).
 
@@ -63,7 +93,7 @@ def on_transform_llm_output(response_text=None, session_id=None, **kwargs):
     # transform_llm_output runs in the agent's worker thread (no running loop here),
     # so hand _respond to the gateway loop captured on inbound. A bare create_task
     # raises "no running event loop" and the naturalize call is silently lost.
-    _coro = _respond(sid, draft, epoch, _build_system_prompt_for_turn_taking(None, sid), meta)
+    _coro = _respond(sid, draft, epoch, _with_memory(_build_system_prompt_for_turn_taking(None, sid), sid), meta)
     try:
         if state.LOOP is not None:
             asyncio.run_coroutine_threadsafe(_coro, state.LOOP)  # bubbles delivered via WS

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, Optional
 
@@ -121,9 +122,33 @@ async def _post(path: str, body: Dict[str, Any]) -> Optional[Dict[str, Any]]:
 
 
 # ── Actions ───────────────────────────────────────────────────────────────────
+def _memory_bank_id() -> str:
+    """The social-memory bank this agent reads/writes. Stable per-agent (the bot's
+    name) so it remembers people across ALL its channels, not per channel.
+    ``HUMALIKE_MEMORY_BANK_ID`` overrides — e.g. to run several distinct agents,
+    each with its own bank."""
+    override = os.getenv("HUMALIKE_MEMORY_BANK_ID", "").strip()
+    if override:
+        return override
+    # Deferred import: core imports this module, so import at call time to avoid
+    # a cycle. _agent_name() reads config only (no Hermes runtime).
+    from .core import _agent_name
+
+    return _agent_name()
+
+
 async def open_thread(thread_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
-    """Open/reopen a thread (id = idempotency key). Returns {thread, channel, realtime}."""
-    return await _post(OPEN_THREAD_PATH, {"thread_id": thread_id} if thread_id else {})
+    """Open/reopen a thread (id = idempotency key). Returns {thread, channel, realtime}.
+
+    Enables **social memory** for the thread: the agent remembers what it learns
+    about the people here and gets that context back on each decide
+    (``recalled_context`` on the response). Scoped to ``memory_bank_id`` so one
+    agent shares memory across its channels."""
+    body: Dict[str, Any] = {"thread_id": thread_id} if thread_id else {}
+    bank = _memory_bank_id()
+    if bank:
+        body["integrations"] = {"social_memory": {"memory_bank_id": bank[:255]}}
+    return await _post(OPEN_THREAD_PATH, body)
 
 
 async def submit_messages(

--- a/turn_taking/state.py
+++ b/turn_taking/state.py
@@ -49,6 +49,13 @@ LAST_CHAT_ID: str = ""
 SESSIONS: Dict[str, str] = {}  # Hermes session_id → turn-taking thread_id
 OPEN_LOCK = asyncio.Lock()     # serializes thread-opens (rare) so a burst can't double-open
 
+# ── Social memory: the context recalled at decide, reused this turn ───────────
+# session_id → recalled_context (what the agent remembers about the people here),
+# returned by submit_messages and reused for BOTH the reply draft (pre_llm_call
+# hook) and the respond system_prompt — one recall per turn, no second lookup.
+# "" when off/empty; overwritten each decide, so it tracks the latest turn.
+MEMORY_BY_SESSION: Dict[str, str] = {}
+
 # ── Decide gate: per-turn epoch ───────────────────────────────────────────────
 # Per-turn epoch keyed by the platform message_id of the message that turn answers.
 # Keying by message_id — not by a single per-session slot — binds each draft


### PR DESCRIPTION
Adds **social memory** to the turn-taking integration: the agent remembers what it learns about the people it talks to, and that context shapes its replies. Follows the same pattern as the existing social-learning voice card.

## What it does
- **`open_thread`** enables the `social_memory` integration, scoped to a stable per-agent **`memory_bank_id`** (the bot's name; `HUMALIKE_MEMORY_BANK_ID` overrides), so one agent shares memory across all its channels rather than per channel.
- The decide response's **`recalled_context`** is reused for the turn: injected into the reply **draft** via a `pre_llm_call` hook, and folded into the respond `system_prompt` so the reply-refinement steps see it too. One recall per turn, no second lookup.

## Layering
Leaves native memory (durable facts) and the voice card (style) untouched; this adds the person-centric memory layer alongside them. Both `pre_llm_call` hooks (card + memory) run.

## Best-effort
No memory, an empty scope, or an API that returns no `recalled_context` → the hooks simply no-op and turn-taking is unchanged. Every path is isolated by the host's hook error handling.

## Tests
`tests/test_social_memory.py`: `open_thread` enables the integration with the bank id (+ 255-char cap), the `pre_llm_call` hook injects only when memory is present, and the respond-prompt fold-in works. (The pre-existing `test_to_messages` direct-run failure is unrelated — it fails on `main` too.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added social-memory support for turn-taking, including automatic recall injection into the response context and the respond system prompt when available.
  * Conversation setup can associate sessions with a configurable social-memory bank ID (truncated to 255 characters).
* **Bug Fixes**
  * Recalled context is now persisted per session and cleared when no result is available, preventing stale or missing memory during a turn.
* **Tests**
  * Added coverage for memory bank propagation, identifier capping, conditional pre-LLM injection, and prompt integration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->