### PR TITLE
config hygiene: opt-in native-memory style strip + misconfig warnings for reply-leaking settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -214,23 +214,31 @@ def _warn_misconfig() -> None:
             problems.append("group_sessions_per_user is not false — set "
                             "'group_sessions_per_user: false' (group chats need one shared thread).")
         display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
-        if display.get("tool_progress") != "off":
-            problems.append("display.tool_progress is not 'off' — tool-call chatter "
+        # Each check mirrors the gateway's own normalization of YAML quirks
+        # (bare `off`/`no` parse as booleans; strings are lowercased), so we
+        # only warn on configs the gateway would actually misread.
+        tp = display.get("tool_progress")
+        tp = "off" if tp is False else "all" if tp is True else str(tp).lower() if tp is not None else None
+        if tp not in ("off", "log"):  # gateway: chatter posts unless mode ∈ {off, log}
+            problems.append("display.tool_progress is not \"off\" — tool-call chatter "
                             "(Browsing/Clicking…) leaks into replies; set "
-                            "'display.tool_progress: off' in ~/.hermes/config.yaml.")
-        if display.get("busy_ack_enabled") is not False:
+                            "'display.tool_progress: \"off\"' in ~/.hermes/config.yaml.")
+        ack = display.get("busy_ack_enabled")
+        if ack is None or str(ack).lower() == "true":  # gateway: enabled iff str(v) == "true"
             problems.append("display.busy_ack_enabled is not false — deterministic "
                             "'⚡ Interrupting current task…' acks are posted; set "
                             "'display.busy_ack_enabled: false' in ~/.hermes/config.yaml.")
-        if display.get("memory_notifications") != "off":
-            problems.append("display.memory_notifications is not the string 'off' — "
-                            "'💾 Self-improvement review…' memory posts leak (a bare YAML "
-                            "'off' parses as False, which the gateway treats as \"on\"); set "
+        mem = display.get("memory_notifications")
+        if not (mem is False or (isinstance(mem, str) and mem.lower() == "off")):
+            problems.append("display.memory_notifications is not \"off\" — "
+                            "'💾 Self-improvement review…' memory posts leak; set "
                             "'display.memory_notifications: \"off\"' in ~/.hermes/config.yaml.")
         if os.environ.get("TELEGRAM_BOT_TOKEN"):
             platforms = display.get("platforms") if isinstance(display.get("platforms"), dict) else {}
             telegram = platforms.get("telegram") if isinstance(platforms.get("telegram"), dict) else {}
-            if telegram.get("streaming") is not False:
+            stream = telegram.get("streaming")
+            stream = stream.lower() in ("true", "1", "yes", "on") if isinstance(stream, str) else stream
+            if stream is None or bool(stream):  # absent, or normalizes truthy → streams
                 problems.append("display.platforms.telegram.streaming is not false — the raw "
                                 "draft streams before naturalization; set "
                                 "'display.platforms.telegram.streaming: false' in "

--- a/__init__.py
+++ b/__init__.py
@@ -184,6 +184,30 @@ def _warn_misconfig() -> None:
     push stays queued (no inbound path installs), so it arrives — not is lost —
     once the plugin is configured.
     """
+    def gateway_bool(v):
+        """String→bool exactly like the gateway's display_config._normalise:
+        truthy iff lower() ∈ {true, 1, yes, on}; non-strings via bool()."""
+        return v.lower() in ("true", "1", "yes", "on") if isinstance(v, str) else bool(v)
+
+    def chatter_suppressed(v):
+        """display.tool_progress keeps chatter out of chat. Mirrors _normalise
+        (False→"off", True→"all", strings lowercased) + run.py, which posts
+        progress unless the mode is "off" or "log"."""
+        if isinstance(v, bool):
+            v = "off" if not v else "all"
+        return v is not None and str(v).lower() in ("off", "log")
+
+    def memory_posts_off(v):
+        """display.memory_notifications is off. Mirrors the gateway/TUI readers:
+        bool → "on"/"off", other falsy → "on", strings lowercased."""
+        return (not v) if isinstance(v, bool) else (isinstance(v, str) and v.lower() == "off")
+
+    def busy_acks_on(v):
+        """display.busy_ack_enabled posts acks. The gateway bridges str(v)
+        through an env var and enables iff it equals "true" — absent defaults
+        on, and only exact true-spellings enable."""
+        return v is None or str(v).lower() == "true"
+
     problems = []
     if not _config.service_url():
         problems.append("HUMALIKE_API_URL is set empty — turn-taking is explicitly "
@@ -214,22 +238,18 @@ def _warn_misconfig() -> None:
             problems.append("group_sessions_per_user is not false — set "
                             "'group_sessions_per_user: false' (group chats need one shared thread).")
         display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
-        # Each check mirrors the gateway's own normalization of YAML quirks
-        # (bare `off`/`no` parse as booleans; strings are lowercased), so we
-        # only warn on configs the gateway would actually misread.
-        tp = display.get("tool_progress")
-        tp = "off" if tp is False else "all" if tp is True else str(tp).lower() if tp is not None else None
-        if tp not in ("off", "log"):  # gateway: chatter posts unless mode ∈ {off, log}
+        # Each check normalizes the value the way the gateway itself does (the
+        # helpers above), so we only warn on configs the gateway would actually
+        # misread — never on a spelling it accepts (bare `off`, "false", "NO").
+        if not chatter_suppressed(display.get("tool_progress")):
             problems.append("display.tool_progress is not \"off\" — tool-call chatter "
                             "(Browsing/Clicking…) leaks into replies; set "
                             "'display.tool_progress: \"off\"' in ~/.hermes/config.yaml.")
-        ack = display.get("busy_ack_enabled")
-        if ack is None or str(ack).lower() == "true":  # gateway: enabled iff str(v) == "true"
+        if busy_acks_on(display.get("busy_ack_enabled")):
             problems.append("display.busy_ack_enabled is not false — deterministic "
                             "'⚡ Interrupting current task…' acks are posted; set "
                             "'display.busy_ack_enabled: false' in ~/.hermes/config.yaml.")
-        mem = display.get("memory_notifications")
-        if not (mem is False or (isinstance(mem, str) and mem.lower() == "off")):
+        if not memory_posts_off(display.get("memory_notifications")):
             problems.append("display.memory_notifications is not \"off\" — "
                             "'💾 Self-improvement review…' memory posts leak; set "
                             "'display.memory_notifications: \"off\"' in ~/.hermes/config.yaml.")
@@ -237,8 +257,7 @@ def _warn_misconfig() -> None:
             platforms = display.get("platforms") if isinstance(display.get("platforms"), dict) else {}
             telegram = platforms.get("telegram") if isinstance(platforms.get("telegram"), dict) else {}
             stream = telegram.get("streaming")
-            stream = stream.lower() in ("true", "1", "yes", "on") if isinstance(stream, str) else stream
-            if stream is None or bool(stream):  # absent, or normalizes truthy → streams
+            if stream is None or gateway_bool(stream):  # absent, or normalizes truthy → streams
                 problems.append("display.platforms.telegram.streaming is not false — the raw "
                                 "draft streams before naturalization; set "
                                 "'display.platforms.telegram.streaming: false' in "

--- a/__init__.py
+++ b/__init__.py
@@ -8,8 +8,9 @@ together:
       build), patching (the gateway monkeypatches), hooks (the plugin hooks)
   - ``social_learning/``  the per-conversation voice card (pre_llm_call hook)
   - ``soul/``             the SOUL.md persona feature (the /soul command)
-  - ``native_memory``     strips native memory's *style* capture (the voice card
-                          above owns style) so the two layers don't double-record
+  - ``native_memory``     optionally strips native memory's *style* capture so
+                          the voice card owns style; off unless
+                          ``native_memory.strip_style: true`` in config.yaml
 
 This module only registers the plugin's command, hooks, and patches.
 """
@@ -212,6 +213,35 @@ def _warn_misconfig() -> None:
         if cfg.get("group_sessions_per_user", True):  # Hermes defaults this to true
             problems.append("group_sessions_per_user is not false — set "
                             "'group_sessions_per_user: false' (group chats need one shared thread).")
+        display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
+        if display.get("tool_progress") != "off":
+            problems.append("display.tool_progress is not 'off' — tool-call chatter "
+                            "(Browsing/Clicking…) leaks into replies; set "
+                            "'display.tool_progress: off' in ~/.hermes/config.yaml.")
+        if display.get("busy_ack_enabled") is not False:
+            problems.append("display.busy_ack_enabled is not false — deterministic "
+                            "'⚡ Interrupting current task…' acks are posted; set "
+                            "'display.busy_ack_enabled: false' in ~/.hermes/config.yaml.")
+        if display.get("memory_notifications") != "off":
+            problems.append("display.memory_notifications is not the string 'off' — "
+                            "'💾 Self-improvement review…' memory posts leak (a bare YAML "
+                            "'off' parses as False, which the gateway treats as \"on\"); set "
+                            "'display.memory_notifications: \"off\"' in ~/.hermes/config.yaml.")
+        if os.environ.get("TELEGRAM_BOT_TOKEN"):
+            platforms = display.get("platforms") if isinstance(display.get("platforms"), dict) else {}
+            telegram = platforms.get("telegram") if isinstance(platforms.get("telegram"), dict) else {}
+            if telegram.get("streaming") is not False:
+                problems.append("display.platforms.telegram.streaming is not false — the raw "
+                                "draft streams before naturalization; set "
+                                "'display.platforms.telegram.streaming: false' in "
+                                "~/.hermes/config.yaml.")
+        agent = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+        disabled = agent.get("disabled_toolsets")
+        disabled = disabled if isinstance(disabled, list) else []
+        if "clarify" not in disabled:
+            problems.append("agent.disabled_toolsets does not include 'clarify' — the "
+                            "clarify tool's numbered menus bypass naturalization; add "
+                            "'clarify' to agent.disabled_toolsets in ~/.hermes/config.yaml.")
     problems += _platform_config_problems(cfg)
     for p in problems:
         _log.warning("turn-taking: %s", p)
@@ -283,9 +313,8 @@ def register(ctx) -> None:
         social_learning.warm_recent_sessions()
     except Exception as e:
         _log.warning("turn-taking: social-learning warm-up skipped: %s", e)
-    # Native memory owns durable FACTS; the voice card above owns STYLE. Stop
-    # native memory from also capturing style so the two layers don't
-    # double-record it (and a stale snapshot can't fight the live card).
+    # Off by default; opt in with ``native_memory.strip_style: true`` to stop
+    # native memory from also capturing style (the voice card owns style).
     try:
         native_memory.strip_native_style_capture()
     except Exception as e:

--- a/native_memory.py
+++ b/native_memory.py
@@ -15,6 +15,9 @@ Two edits, both at load time, no hooks:
   2. ``MEMORY_GUIDANCE`` — imported by-name into ``agent.system_prompt`` and
      ``agent.prompt_builder``, so we patch the binding the prompt builder reads.
 
+Opt-in: does nothing unless ``native_memory.strip_style: true`` is set in
+config.yaml — by default native memory is left completely stock.
+
 Best-effort and idempotent; never raises. No-op on a Hermes without these
 internals (the imports simply fail and each edit reports False). The host
 imports are deferred into the functions so importing this module never needs
@@ -29,6 +32,17 @@ import logging
 from typing import Any
 
 _log = logging.getLogger(__name__)
+
+
+def _enabled() -> bool:
+    """Opt-in via ``native_memory.strip_style: true`` in config.yaml. Off by
+    default: native memory is left completely stock unless asked."""
+    try:
+        from hermes_cli.config import load_config, cfg_get  # noqa: PLC0415
+
+        return bool(cfg_get(load_config(), "native_memory", "strip_style", default=False))
+    except Exception:
+        return False
 
 # Explicit prohibition injected into both the tool schema and the guidance.
 # The marker lets us stay idempotent (don't append twice on re-register).
@@ -109,7 +123,10 @@ def _strip_guidance_style() -> bool:
 
 def strip_native_style_capture() -> tuple[bool, bool]:
     """Apply both edits at register time. Returns ``(schema_patched,
-    guidance_patched)`` for logging/tests; never raises."""
+    guidance_patched)`` for logging/tests; never raises. No-op unless
+    ``native_memory.strip_style: true`` is set in config.yaml."""
+    if not _enabled():
+        return False, False
     schema = _strip_schema_style()
     guidance = _strip_guidance_style()
     _log.info(

--- a/skills/install-turn-taking/SKILL.md
+++ b/skills/install-turn-taking/SKILL.md
@@ -73,7 +73,16 @@ Then merge into `~/.hermes/config.yaml` (create if missing) — all **required**
 streaming: false
 group_sessions_per_user: false
 display:
-  tool_progress: "off"   # hide tool-call chatter (Browsing/Clicking/…) so replies read as human
+  tool_progress: "off"        # hide tool-call chatter (Browsing/Clicking/…) so replies read as human
+  busy_ack_enabled: false     # no deterministic "⚡ Interrupting current task…" acks
+  memory_notifications: "off" # no "💾 Self-improvement review…" posts — MUST be the quoted
+                              # string; bare YAML `off` parses as false and turns back into "on"
+  platforms:
+    telegram:
+      streaming: false        # Telegram draft streaming shows the raw draft before naturalization
+agent:
+  disabled_toolsets: [clarify] # clarify's numbered menus bypass naturalization; without the
+                               # tool the bot asks in plain text
 slack:
   reply_in_thread: false # only if Slack is used — one shared conversation per channel
 

--- a/tests/test_misconfig.py
+++ b/tests/test_misconfig.py
@@ -7,13 +7,12 @@ Run directly:  python3 tests/test_misconfig.py
 """
 
 import importlib.util
+import json
 import os
 import sys
 import types
 from pathlib import Path
 from unittest.mock import patch
-
-import yaml
 
 _ROOT = Path(__file__).resolve().parent.parent
 
@@ -134,6 +133,11 @@ _CLEAN_ENV = {"TELEGRAM_BOT_TOKEN": "t", "HUMALIKE_API_KEY": "k"}
 def test_warn_misconfig_core_display_and_agent_checks():
     """The five autoconfigured 'core' settings _warn_misconfig now verifies:
     clean cfg -> no problems; each one missing/wrong -> its own message."""
+    # _warn_misconfig itself parses config with PyYAML; without it the checks
+    # are skipped by design, so there is nothing to exercise here.
+    if importlib.util.find_spec("yaml") is None:
+        print("skip test_warn_misconfig_core_display_and_agent_checks (needs PyYAML)")
+        return
     with patch.dict(os.environ, _CLEAN_ENV, clear=True):
         probs = _extract_core_problems(_CLEAN_CORE_CFG)
     assert probs == [], probs
@@ -184,7 +188,7 @@ def _extract_core_problems(cfg):
     with patch.object(_MOD, "_platform_config_problems", return_value=[]), \
          patch.object(_MOD, "_should_chat_warn", return_value=False), \
          patch.object(_MOD.login, "_hermes_home", return_value=Path("/nonexistent")), \
-         patch("pathlib.Path.read_text", return_value=yaml.dump(cfg)), \
+         patch("pathlib.Path.read_text", return_value=json.dumps(cfg)), \
          patch.object(_MOD._log, "warning", side_effect=lambda fmt, p: captured.append(p)):
         _MOD._warn_misconfig()
     return captured

--- a/tests/test_misconfig.py
+++ b/tests/test_misconfig.py
@@ -146,12 +146,29 @@ def test_warn_misconfig_core_display_and_agent_checks():
     assert any("platforms.telegram.streaming" in p for p in probs), probs
     assert any("disabled_toolsets" in p for p in probs), probs
 
-    # A bare YAML `off` (-> False) for memory_notifications still warns: must
-    # be the STRING "off".
+    # Spellings the gateway normalizes to the same behavior are compliant:
+    # bare YAML `off` (-> False), case variants, stringy booleans.
+    lenient = {
+        "tool_progress": False,            # gateway: False -> "off"
+        "busy_ack_enabled": "false",       # gateway: enabled iff str(v)=="true"
+        "memory_notifications": False,     # gateway: bool False -> "off"
+        "platforms": {"telegram": {"streaming": "no"}},  # gateway: str -> bool
+    }
     with patch.dict(os.environ, _CLEAN_ENV, clear=True):
-        cfg = {**_CLEAN_CORE_CFG, "display": {**_CLEAN_CORE_CFG["display"], "memory_notifications": False}}
-        probs = _extract_core_problems(cfg)
-    assert any("memory_notifications" in p for p in probs), probs
+        probs = _extract_core_problems({**_CLEAN_CORE_CFG, "display": lenient})
+    assert probs == [], probs
+
+    # Truthy-normalizing spellings still warn.
+    noisy = {
+        "tool_progress": "all",
+        "busy_ack_enabled": "TRUE",
+        "memory_notifications": "verbose",
+        "platforms": {"telegram": {"streaming": "yes"}},
+    }
+    with patch.dict(os.environ, _CLEAN_ENV, clear=True):
+        probs = _extract_core_problems({**_CLEAN_CORE_CFG, "display": noisy})
+    for key in ("tool_progress", "busy_ack_enabled", "memory_notifications", "telegram.streaming"):
+        assert any(key in p for p in probs), (key, probs)
 
     # Telegram streaming only warned when a Telegram bot token is in use.
     with patch.dict(os.environ, {"HUMALIKE_API_KEY": "k"}, clear=True):

--- a/tests/test_misconfig.py
+++ b/tests/test_misconfig.py
@@ -13,6 +13,8 @@ import types
 from pathlib import Path
 from unittest.mock import patch
 
+import yaml
+
 _ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -113,6 +115,62 @@ def test_platform_problems_whatsapp():
     # Enabled with default policy -> pairing warning.
     with patch.dict(os.environ, {"WHATSAPP_ENABLED": "true"}, clear=True):
         assert any("pairing" in p for p in _MOD._platform_config_problems({}))
+
+
+_CLEAN_CORE_CFG = {
+    "streaming": False,
+    "group_sessions_per_user": False,
+    "display": {
+        "tool_progress": "off",
+        "busy_ack_enabled": False,
+        "memory_notifications": "off",
+        "platforms": {"telegram": {"streaming": False}},
+    },
+    "agent": {"disabled_toolsets": ["clarify"]},
+}
+_CLEAN_ENV = {"TELEGRAM_BOT_TOKEN": "t", "HUMALIKE_API_KEY": "k"}
+
+
+def test_warn_misconfig_core_display_and_agent_checks():
+    """The five autoconfigured 'core' settings _warn_misconfig now verifies:
+    clean cfg -> no problems; each one missing/wrong -> its own message."""
+    with patch.dict(os.environ, _CLEAN_ENV, clear=True):
+        probs = _extract_core_problems(_CLEAN_CORE_CFG)
+    assert probs == [], probs
+
+    with patch.dict(os.environ, _CLEAN_ENV, clear=True):
+        probs = _extract_core_problems({**_CLEAN_CORE_CFG, "display": {}, "agent": {}})
+    assert any("tool_progress" in p for p in probs), probs
+    assert any("busy_ack_enabled" in p for p in probs), probs
+    assert any("memory_notifications" in p for p in probs), probs
+    assert any("platforms.telegram.streaming" in p for p in probs), probs
+    assert any("disabled_toolsets" in p for p in probs), probs
+
+    # A bare YAML `off` (-> False) for memory_notifications still warns: must
+    # be the STRING "off".
+    with patch.dict(os.environ, _CLEAN_ENV, clear=True):
+        cfg = {**_CLEAN_CORE_CFG, "display": {**_CLEAN_CORE_CFG["display"], "memory_notifications": False}}
+        probs = _extract_core_problems(cfg)
+    assert any("memory_notifications" in p for p in probs), probs
+
+    # Telegram streaming only warned when a Telegram bot token is in use.
+    with patch.dict(os.environ, {"HUMALIKE_API_KEY": "k"}, clear=True):
+        cfg = {**_CLEAN_CORE_CFG, "display": {**_CLEAN_CORE_CFG["display"], "platforms": {}}}
+        probs = _extract_core_problems(cfg)
+    assert not any("telegram.streaming" in p for p in probs), probs
+
+
+def _extract_core_problems(cfg):
+    """Run _warn_misconfig with the config-file read and platform/chat-warn
+    side effects stubbed out, capturing the resulting problems list."""
+    captured = []
+    with patch.object(_MOD, "_platform_config_problems", return_value=[]), \
+         patch.object(_MOD, "_should_chat_warn", return_value=False), \
+         patch.object(_MOD.login, "_hermes_home", return_value=Path("/nonexistent")), \
+         patch("pathlib.Path.read_text", return_value=yaml.dump(cfg)), \
+         patch.object(_MOD._log, "warning", side_effect=lambda fmt, p: captured.append(p)):
+        _MOD._warn_misconfig()
+    return captured
 
 
 def test_chat_warn_digest_marker():

--- a/tests/test_native_memory.py
+++ b/tests/test_native_memory.py
@@ -103,6 +103,39 @@ def test_noop_without_host_never_raises():
     assert nm.strip_native_style_capture() == (False, False)
 
 
+def test_gated_off_by_default():
+    """Without ``native_memory.strip_style: true`` in config, the public entry
+    is a pure no-op even with a live host present."""
+    nm = _load()
+    schema = _install_tools("Save name, communication style.")
+    _install_agent("Memory guidance. " + _STYLE_EXAMPLE)
+    assert nm._enabled() is False  # no hermes_cli.config here → default off
+    assert nm.strip_native_style_capture() == (False, False)
+    assert "communication style" in schema["description"], "schema untouched"
+    _clear_host()
+
+
+def test_gate_opt_in():
+    nm = _load()
+    cfg = types.ModuleType("hermes_cli.config")
+    cfg.load_config = lambda: {"native_memory": {"strip_style": True}}
+    cfg.cfg_get = lambda c, *path, default=None: (
+        c.get(path[0], {}).get(path[1], default) if len(path) == 2 else default
+    )
+    hermes_cli = types.ModuleType("hermes_cli")
+    hermes_cli.config = cfg
+    sys.modules["hermes_cli"] = hermes_cli
+    sys.modules["hermes_cli.config"] = cfg
+    schema = _install_tools("Save name, communication style.")
+    _install_agent("Memory guidance. " + _STYLE_EXAMPLE)
+    assert nm._enabled() is True
+    assert nm.strip_native_style_capture() == (True, True)
+    assert "communication style" not in schema["description"]
+    sys.modules.pop("hermes_cli", None)
+    sys.modules.pop("hermes_cli.config", None)
+    _clear_host()
+
+
 def test_facts_survive():
     """The point of the plugin: FACT wording is untouched, only STYLE is cut."""
     nm = _load()
@@ -118,5 +151,7 @@ if __name__ == "__main__":
     test_schema_strip_and_idempotent()
     test_guidance_strip_both_modules_and_idempotent()
     test_noop_without_host_never_raises()
+    test_gated_off_by_default()
+    test_gate_opt_in()
     test_facts_survive()
     print("native_memory: all checks passed ✓")

--- a/tests/test_native_memory.py
+++ b/tests/test_native_memory.py
@@ -10,6 +10,7 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
+from unittest.mock import patch
 
 _ROOT = Path(__file__).resolve().parent.parent
 
@@ -103,36 +104,41 @@ def test_noop_without_host_never_raises():
     assert nm.strip_native_style_capture() == (False, False)
 
 
+def _host_cfg(config):
+    """Fake ``hermes_cli.config`` serving ``config``, as a sys.modules mapping
+    for patch.dict — so the gate never reads the machine's real Hermes install
+    (or its live config.yaml), and state is restored even on assert failure."""
+    cfg = types.ModuleType("hermes_cli.config")
+    cfg.load_config = lambda: config
+    cfg.cfg_get = lambda c, *path, default=None: (
+        c.get(path[0], {}).get(path[1], default) if len(path) == 2 else default
+    )
+    hermes_cli = types.ModuleType("hermes_cli")
+    hermes_cli.config = cfg
+    return {"hermes_cli": hermes_cli, "hermes_cli.config": cfg}
+
+
 def test_gated_off_by_default():
     """Without ``native_memory.strip_style: true`` in config, the public entry
     is a pure no-op even with a live host present."""
     nm = _load()
     schema = _install_tools("Save name, communication style.")
     _install_agent("Memory guidance. " + _STYLE_EXAMPLE)
-    assert nm._enabled() is False  # no hermes_cli.config here → default off
-    assert nm.strip_native_style_capture() == (False, False)
+    with patch.dict(sys.modules, _host_cfg({})):  # host importable, key unset
+        assert nm._enabled() is False
+        assert nm.strip_native_style_capture() == (False, False)
     assert "communication style" in schema["description"], "schema untouched"
     _clear_host()
 
 
 def test_gate_opt_in():
     nm = _load()
-    cfg = types.ModuleType("hermes_cli.config")
-    cfg.load_config = lambda: {"native_memory": {"strip_style": True}}
-    cfg.cfg_get = lambda c, *path, default=None: (
-        c.get(path[0], {}).get(path[1], default) if len(path) == 2 else default
-    )
-    hermes_cli = types.ModuleType("hermes_cli")
-    hermes_cli.config = cfg
-    sys.modules["hermes_cli"] = hermes_cli
-    sys.modules["hermes_cli.config"] = cfg
     schema = _install_tools("Save name, communication style.")
     _install_agent("Memory guidance. " + _STYLE_EXAMPLE)
-    assert nm._enabled() is True
-    assert nm.strip_native_style_capture() == (True, True)
+    with patch.dict(sys.modules, _host_cfg({"native_memory": {"strip_style": True}})):
+        assert nm._enabled() is True
+        assert nm.strip_native_style_capture() == (True, True)
     assert "communication style" not in schema["description"]
-    sys.modules.pop("hermes_cli", None)
-    sys.modules.pop("hermes_cli.config", None)
     _clear_host()
 
 


### PR DESCRIPTION
## Two changes

### 1. `native_memory` style-strip is now opt-in (default: off)
Previously the plugin always patched Hermes native memory at register time (stripping style capture from the memory tool schema and `MEMORY_GUIDANCE`). Now it is a no-op unless `native_memory.strip_style: true` is set in `~/.hermes/config.yaml` — native memory stays completely stock by default. The `HUMALIKE_MEMORY_BANK_ID`-style env override pattern is not needed; the gate reads `hermes_cli.config` and fails closed (off) if the host config is unavailable.

### 2. `_warn_misconfig` covers five more reply-leaking settings
New warnings (with copy-pasteable fixes) for:
- `display.tool_progress` ≠ `"off"` — tool-call chatter (Browsing/Clicking…) leaks into replies
- `display.busy_ack_enabled` ≠ `false` — deterministic "⚡ Interrupting current task…" acks get posted
- `display.memory_notifications` ≠ the **string** `"off"` — bare YAML `off` parses as `False`, which the gateway treats as "on"; "💾 Self-improvement review…" posts leak
- `display.platforms.telegram.streaming` ≠ `false` (only when `TELEGRAM_BOT_TOKEN` is set) — raw draft streams before naturalization
- `clarify` missing from `agent.disabled_toolsets` — clarify's numbered menus bypass naturalization

`skills/install-turn-taking/SKILL.md` config template updated to match.

## Tests
- `tests/test_native_memory.py`: gate off by default (host untouched), opt-in flips both patches on
- `tests/test_misconfig.py`: clean config → no problems; each setting missing/wrong → its own message; bare-`off` footgun; telegram check skipped without a bot token

Both suites pass (`python3 tests/test_native_memory.py`, `uv run --with pyyaml python tests/test_misconfig.py`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native memory conversational style stripping is now opt-in via `native_memory.strip_style: true`; it remains off by default.
  * Startup misconfiguration warnings now include additional `display`/`agent` checks, with Telegram streaming warnings shown only when Telegram is in use.
* **Documentation**
  * Updated the turn-taking skill configuration example to include the newly required `display`, Telegram, and `agent` settings.
* **Tests**
  * Added coverage for the expanded misconfiguration warnings and for native memory opt-in gating behavior (including default no-op verification).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->