### PR TITLE
Discord support: turn-taking gate, media, mentions, typing + merged-turn epoch fix (re-land on main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # Humalike Plugin
 
-One command gives your Hermes agent social intelligence. It decides when to speak, adapts to your group's tone and remembers who said what. Works in group chats on Slack, Telegram and WhatsApp, powered by the [Humalike](https://docs.humalike.com) APIs:
+One command gives your Hermes agent social intelligence. It decides when to speak, adapts to your group's tone and remembers who said what. Works in group chats on Slack, Telegram, WhatsApp and Discord, powered by the [Humalike](https://docs.humalike.com) APIs:
 
 - **[Turn-taking](https://docs.humalike.com/api-reference/turn-taking/overview)** -
   decides when to jump in vs stay silent, and naturalizes replies so they read
@@ -99,6 +99,21 @@ plugin's report ends with that reminder.
   replies to *everyone* who messages that number, in DMs and all groups. If it's
   your personal number, tighten it (the plugin warns about this at setup):
   `WHATSAPP_ALLOW_ALL_USERS=false` and/or `WHATSAPP_GROUP_POLICY=allowlist`.
+- **Discord bot setup** - steps that can't be automated. Create the bot in the
+  [Developer Portal](https://discord.com/developers/applications), enable
+  **Message Content Intent** and **Server Members Intent** (Bot → Privileged
+  Gateway Intents - without the first the bot receives empty messages), invite
+  it with
+  `https://discord.com/oauth2/authorize?client_id=<APP_ID>&scope=bot+applications.commands&permissions=274878286912`,
+  then add to `~/.hermes/.env`:
+  ```bash
+  DISCORD_BOT_TOKEN=...                # from the Developer Portal
+  DISCORD_ALLOWED_USERS=<user-id,...>  # without this the gateway denies everyone
+  DISCORD_REQUIRE_MENTION=false        # let turn-taking see unmentioned channel messages
+  #  (or per-channel: DISCORD_FREE_RESPONSE_CHANNELS=<channel-id,...>)
+  DISCORD_AUTO_THREAD=false            # reply inline; auto-threads would fragment the room
+  DISCORD_REACTIONS=false              # no 👀/✅ ack reactions
+  ```
 
 ### Overrides
 
@@ -123,6 +138,23 @@ replies when it has something to say.
 | WhatsApp | DMs work as-is. Groups: [`skills/configure-whatsapp-group`](skills/configure-whatsapp-group/SKILL.md) |
 | Telegram | DMs work as-is. Groups: [`skills/configure-telegram-group`](skills/configure-telegram-group/SKILL.md) |
 | Slack | DMs/@mentions work as-is. Unmentioned channel messages: [`skills/configure-slack-group`](skills/configure-slack-group/SKILL.md) |
+| Discord | DMs work as-is. Channels: enable both privileged intents, set `DISCORD_ALLOWED_USERS`, and `DISCORD_REQUIRE_MENTION=false` (or `DISCORD_FREE_RESPONSE_CHANNELS=<channel-id,...>`) - see **Discord bot setup** above |
+
+### Discord notes
+
+- **Typing indicator** - Discord's typing is a persistent refresh loop, so the
+  plugin mutes the host's think-time typing and shows typing only while a reply
+  bubble is being paced, with an explicit stop after the last bubble.
+- **Captionless media** - images/files sent without text reach the service as a
+  clean `[image]`/`[media]` marker (with `has_media`), not the host's
+  placeholder sentence, so turn-taking knows media arrived.
+- **Fast message bursts** - a follow-up that arrives while the bot is composing
+  is merged into the in-flight turn and the reply is re-stamped with the newest
+  turn epoch, so quick "hermes" / "are you here?" bursts get an answer instead
+  of a silently superseded one.
+- **Mentions** - `<@id>`/`<@!id>` tokens are resolved for the service: the bot's
+  own mention becomes `@you`, other people become `@DisplayName`.
+- Slash commands (`/new`, `/sethome`, …) bypass the turn-taking gate.
 
 ## Persona: `/soul enhance`
 

--- a/__init__.py
+++ b/__init__.py
@@ -29,6 +29,8 @@ from .turn_taking.patching import (
     _patch_merge_pending_message_event,
     _patch__poll_messages,
     _patch_send,
+    _patch_discord_handle_message,
+    _patch_discord_send_typing,
     _patch_slack_handle_message,
     _patch_telegram_handle_message,
     _patch_telegram_observe_group,
@@ -363,6 +365,8 @@ def register(ctx) -> None:
     tg_media = _patch_telegram_handle_message()
     tg_group = _patch_telegram_observe_group()
     slack = _patch_slack_handle_message()
+    discord = _patch_discord_handle_message()
+    discord_typing = _patch_discord_send_typing()
     merge_fix = _patch_merge_pending_message_event()
     hooked = False
     try:
@@ -370,5 +374,5 @@ def register(ctx) -> None:
         hooked = True
     except Exception as e:
         _log.warning("turn-taking: could not register transform_llm_output hook: %s", e)
-    _log.info("turn-taking registered (send=%s, inbound=%s, poll=%s, tg_media=%s, tg_group=%s, slack=%s, merge_fix=%s, transform=%s)",
-              sent, inbound, poll, tg_media, tg_group, slack, merge_fix, hooked)
+    _log.info("turn-taking registered (send=%s, inbound=%s, poll=%s, tg_media=%s, tg_group=%s, slack=%s, discord=%s, discord_typing=%s, merge_fix=%s, transform=%s)",
+              sent, inbound, poll, tg_media, tg_group, slack, discord, discord_typing, merge_fix, hooked)

--- a/tests/test_discord_mentions.py
+++ b/tests/test_discord_mentions.py
@@ -1,0 +1,90 @@
+"""Discord branch of `_annotate_mentions`: <@id>/<@!id> → @you / @DisplayName.
+
+patching.py needs its package siblings, so we load state/notify/service for real
+(httpx stubbed) and stub core (only names patching imports). Run directly:
+python3 tests/test_discord_mentions.py  (or via pytest from inside tests/).
+"""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_patching():
+    sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+    httpx = sys.modules["httpx"]
+    if not hasattr(httpx, "HTTPError"):
+        httpx.HTTPStatusError = type("HTTPStatusError", (Exception,), {})
+        httpx.HTTPError = type("HTTPError", (Exception,), {})
+
+    pkg = types.ModuleType("dm_pkg")
+    pkg.__path__ = [str(_ROOT)]
+    sys.modules["dm_pkg"] = pkg
+    tt = types.ModuleType("dm_pkg.turn_taking")
+    tt.__path__ = [str(_ROOT / "turn_taking")]
+    sys.modules["dm_pkg.turn_taking"] = tt
+
+    def _mod(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        m = importlib.util.module_from_spec(spec)
+        sys.modules[name] = m
+        spec.loader.exec_module(m)
+        return m
+
+    _mod("dm_pkg._config", _ROOT / "_config.py")
+    _mod("dm_pkg.turn_taking.state", _ROOT / "turn_taking" / "state.py")
+    _mod("dm_pkg.turn_taking.notify", _ROOT / "turn_taking" / "notify.py")
+    _mod("dm_pkg.turn_taking.service", _ROOT / "turn_taking" / "service.py")
+    core = types.ModuleType("dm_pkg.turn_taking.core")
+    for n in ("_inbound_gate", "_build_system_prompt_for_turn_taking", "_decide", "_delivery_meta"):
+        setattr(core, n, lambda *a, **k: None)
+    sys.modules["dm_pkg.turn_taking.core"] = core
+    return _mod("dm_pkg.turn_taking.patching", _ROOT / "turn_taking" / "patching.py")
+
+
+patching = _load_patching()
+
+
+def _member(mid, display_name=None, name=None):
+    return types.SimpleNamespace(id=mid, display_name=display_name, name=name)
+
+
+def _adapter(bot_id=999):
+    return types.SimpleNamespace(_client=types.SimpleNamespace(user=types.SimpleNamespace(id=bot_id)))
+
+
+def _event(text, mentions):
+    return types.SimpleNamespace(text=text, source=None, raw_message=types.SimpleNamespace(mentions=mentions))
+
+
+def _annotate(adapter, event):
+    asyncio.run(patching._annotate_mentions(adapter, event))
+
+
+def test_self_mention_becomes_you():
+    ev = _event("<@999> hello", [_member(999, "Bot")])
+    _annotate(_adapter(), ev)
+    assert ev._tt_content == "@you hello"
+
+
+def test_other_member_gets_display_name_and_bang_variant():
+    ev = _event("hey <@!42>", [_member(42, "Alice")])
+    _annotate(_adapter(), ev)
+    assert ev._tt_content == "hey @Alice"
+
+
+def test_no_mentions_left_untouched():
+    ev = _event("plain text", [])
+    _annotate(_adapter(), ev)
+    assert not hasattr(ev, "_tt_content")
+
+
+if __name__ == "__main__":
+    test_self_mention_becomes_you()
+    test_other_member_gets_display_name_and_bang_variant()
+    test_no_mentions_left_untouched()
+    print("ok")

--- a/tests/test_misconfig.py
+++ b/tests/test_misconfig.py
@@ -42,7 +42,8 @@ def _load():
     tt.hooks = _stub("turn_taking.hooks", on_transform_llm_output=noop)
     tt.patching = _stub("turn_taking.patching", **{n: (lambda: False) for n in (
         "_patch__enqueue_text_event", "_patch_merge_pending_message_event",
-        "_patch__poll_messages", "_patch_send", "_patch_slack_handle_message",
+        "_patch__poll_messages", "_patch_send", "_patch_discord_handle_message", "_patch_discord_send_typing",
+        "_patch_slack_handle_message",
         "_patch_telegram_handle_message", "_patch_telegram_observe_group")})
     tt.notify = _stub("turn_taking.notify", queue_startup=noop)
     tt.service = _stub("turn_taking.service", _service_url=lambda: "")

--- a/tests/test_to_messages.py
+++ b/tests/test_to_messages.py
@@ -102,6 +102,13 @@ def test_discord_host_placeholder_treated_as_captionless_media():
     assert out == [{"sender": "alice", "content": "[image]", "has_media": True}]
 
 
+def test_host_placeholder_without_media_is_kept_as_text():
+    # A user literally typing the host's placeholder sentence (no media attached)
+    # must keep their text — the blanking is gated on has_media.
+    out = tt._to_messages([_event(text="(The user sent a message with no text content)")])
+    assert out == [{"sender": "alice", "content": "(The user sent a message with no text content)"}]
+
+
 def test_text_message_has_no_media_key():
     assert "has_media" not in tt._to_messages([_event(text="hi")])[0]
 

--- a/tests/test_to_messages.py
+++ b/tests/test_to_messages.py
@@ -1,8 +1,8 @@
 """Checks for `_to_messages` — the media-aware decide-payload builder.
 
-The plugin's __init__.py needs the Hermes loader, so we stub the modules it
-imports (httpx, soul deps) and load it by file path under a throwaway package
-name. Run directly:  python3 tests/test_to_messages.py
+`_to_messages` lives in turn_taking/service.py, which uses relative imports, so
+we stub httpx and load the package by file path under a throwaway package name.
+Run directly:  python3 tests/test_to_messages.py
 """
 
 import importlib.util
@@ -15,14 +15,29 @@ _ROOT = Path(__file__).resolve().parent.parent
 
 def _load_plugin():
     sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+    httpx = sys.modules["httpx"]
+    if not hasattr(httpx, "HTTPError"):
+        httpx.HTTPStatusError = type("HTTPStatusError", (Exception,), {})
+        httpx.HTTPError = type("HTTPError", (Exception,), {})
+
     pkg = types.ModuleType("tt_pkg")
     pkg.__path__ = [str(_ROOT)]
     sys.modules["tt_pkg"] = pkg
-    spec = importlib.util.spec_from_file_location("tt_pkg.__init__", _ROOT / "__init__.py")
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules["tt_pkg.__init__"] = mod
-    spec.loader.exec_module(mod)
-    return mod
+    tt = types.ModuleType("tt_pkg.turn_taking")
+    tt.__path__ = [str(_ROOT / "turn_taking")]
+    sys.modules["tt_pkg.turn_taking"] = tt
+
+    def _mod(name, path):
+        spec = importlib.util.spec_from_file_location(name, path)
+        m = importlib.util.module_from_spec(spec)
+        sys.modules[name] = m
+        spec.loader.exec_module(m)
+        return m
+
+    _mod("tt_pkg._config", _ROOT / "_config.py")
+    _mod("tt_pkg.turn_taking.state", _ROOT / "turn_taking" / "state.py")
+    _mod("tt_pkg.turn_taking.notify", _ROOT / "turn_taking" / "notify.py")
+    return _mod("tt_pkg.turn_taking.service", _ROOT / "turn_taking" / "service.py")
 
 
 def _event(text="", mtype="text", media=None, sender="alice"):
@@ -75,6 +90,16 @@ def test_media_detected_by_urls_even_if_type_text():
     out = tt._to_messages([_event(text="", mtype="text", media=["/tmp/x.jpg"])])
     assert out[0]["has_media"] is True
     assert out[0]["content"] == "[media]"
+
+
+def test_discord_host_placeholder_treated_as_captionless_media():
+    # Discord fills captionless media text with a host placeholder sentence;
+    # it must not leak into the service transcript as content.
+    out = tt._to_messages([_event(
+        text="(The user sent a message with no text content)",
+        mtype="photo", media=["http://x/img.png"],
+    )])
+    assert out == [{"sender": "alice", "content": "[image]", "has_media": True}]
 
 
 def test_text_message_has_no_media_key():

--- a/turn_taking/core.py
+++ b/turn_taking/core.py
@@ -148,11 +148,17 @@ async def _decide(
         if delivery_meta:
             state.META_BY_MESSAGE_ID[message_id] = delivery_meta
     if epoch is not None:
+        # Unconditional (also on stay_silent): every submit bumps the service's
+        # epoch, so this mirrors the server's CURRENT epoch — exactly what a
+        # merged turn's respond must claim, regardless of the decision that
+        # accompanied the newest message.
         state.LATEST_EPOCH_BY_CHAT[str(chat_id)] = epoch
     # ponytail: size-cap the per-message maps (entries for merged-away messages
-    # are never popped); FIFO eviction is fine at this scale.
+    # are never popped). FIFO eviction is blind to liveness — a still-running
+    # turn's entry could be evicted — so the cap is set far above any plausible
+    # number of decides during one turn (minutes-long tool turns included).
     for _m in (state.EPOCH_BY_MESSAGE_ID, state.META_BY_MESSAGE_ID, state.LATEST_EPOCH_BY_CHAT):
-        while len(_m) > 512:
+        while len(_m) > 4096:
             _m.pop(next(iter(_m)))
     _log.info("tt decide: session=%s chat=%s mid=%s decision=%s epoch=%s",
               session_id, chat_id, message_id, decision, epoch)

--- a/turn_taking/core.py
+++ b/turn_taking/core.py
@@ -147,6 +147,13 @@ async def _decide(
         state.EPOCH_BY_MESSAGE_ID[message_id] = epoch
         if delivery_meta:
             state.META_BY_MESSAGE_ID[message_id] = delivery_meta
+    if epoch is not None:
+        state.LATEST_EPOCH_BY_CHAT[str(chat_id)] = epoch
+    # ponytail: size-cap the per-message maps (entries for merged-away messages
+    # are never popped); FIFO eviction is fine at this scale.
+    for _m in (state.EPOCH_BY_MESSAGE_ID, state.META_BY_MESSAGE_ID, state.LATEST_EPOCH_BY_CHAT):
+        while len(_m) > 512:
+            _m.pop(next(iter(_m)))
     _log.info("tt decide: session=%s chat=%s mid=%s decision=%s epoch=%s",
               session_id, chat_id, message_id, decision, epoch)
     return decision

--- a/turn_taking/delivery.py
+++ b/turn_taking/delivery.py
@@ -57,20 +57,32 @@ async def _forward(
 
 
 async def _forward_typing(thread_id: Optional[str], is_typing: Optional[bool]) -> None:
-    """on_typing callback: show "… is typing" on WhatsApp while the reply is paced.
+    """on_typing callback: show "… is typing" while the reply is paced.
 
-    Easy version: fire a one-shot indicator on typing-start. WhatsApp presence
-    auto-expires after a few seconds, so a long paced reply may stop showing it
-    mid-way; refresh-on-a-timer is a later polish if that matters.
+    WhatsApp/Telegram presence auto-expires after a few seconds, so typing-start
+    alone was enough there. Discord's ``send_typing`` instead starts a persistent
+    refresh loop that runs until ``stop_typing`` — without an explicit stop the
+    indicator loops forever after the bubbles land. So: start on typing-start,
+    and on typing-stop call the adapter's ``stop_typing`` when it has one
+    (harmless no-op elsewhere).
     """
-    if not is_typing:
-        return  # presence auto-expires; no explicit stop needed
     route = state.ROUTES.get(thread_id or "")
     if route is None:
         return
     adapter, chat_id = route
     try:
-        await adapter.send_typing(chat_id)
+        if is_typing:
+            # On adapters whose host typing is muted (Discord), call the genuine
+            # send_typing — the patched one is a no-op.
+            orig = state.ORIG_SEND_TYPING.get(type(adapter))
+            if orig is not None:
+                await orig(adapter, chat_id)
+            else:
+                await adapter.send_typing(chat_id)
+        else:
+            stop = getattr(adapter, "stop_typing", None)
+            if stop is not None:
+                await stop(chat_id)
     except Exception as e:
         _log.warning("turn-taking typing failed: %s", e)
 

--- a/turn_taking/delivery.py
+++ b/turn_taking/delivery.py
@@ -73,8 +73,14 @@ async def _forward_typing(thread_id: Optional[str], is_typing: Optional[bool]) -
     try:
         if is_typing:
             # On adapters whose host typing is muted (Discord), call the genuine
-            # send_typing — the patched one is a no-op.
-            orig = state.ORIG_SEND_TYPING.get(type(adapter))
+            # send_typing — the patched one is a no-op. Walk the MRO: the mute is
+            # registered under the resolved base class, but the live adapter may
+            # be a subclass (plain type() lookup would miss and hit the no-op).
+            orig = next(
+                (state.ORIG_SEND_TYPING[c] for c in type(adapter).__mro__
+                 if c in state.ORIG_SEND_TYPING),
+                None,
+            )
             if orig is not None:
                 await orig(adapter, chat_id)
             else:

--- a/turn_taking/hooks.py
+++ b/turn_taking/hooks.py
@@ -83,7 +83,10 @@ def _queued_follow_up(chat: str) -> bool:
         # group/thread variants likewise). Exact-segment match — a substring
         # test would false-positive on numeric ids ("123" ⊂ "…:1234") and skip
         # the re-stamp, silently reintroducing the dropped-reply bug.
-        return any(chat in str(k).split(":") for k in state.PENDING_MAP)
+        # Snapshot first: this runs in the agent worker thread while the gateway
+        # loop mutates the dict; list(dict) is a single GIL-held C call, whereas
+        # iterating the live dict bytecode-by-bytecode can raise RuntimeError.
+        return any(chat in str(k).split(":") for k in list(state.PENDING_MAP))
     except Exception:
         return False
 

--- a/turn_taking/hooks.py
+++ b/turn_taking/hooks.py
@@ -67,6 +67,22 @@ def _with_memory(system_prompt, session_id):
     return f"{system_prompt}\n\n{block}" if system_prompt else block
 
 
+def _queued_follow_up(chat: str) -> bool:
+    """True when the gateway holds a QUEUED follow-up event for this chat.
+
+    ``state.PENDING_MAP`` is the live ``pending_messages`` dict (captured by the
+    merge wrapper); its keys are session keys that embed the chat id. No map yet
+    (nothing was ever queued) → no follow-up. Fail-open to False: worst case we
+    stamp the newest epoch and the service arbitrates via its one-shot claim.
+    """
+    if not chat or not state.PENDING_MAP:
+        return False
+    try:
+        return any(chat in str(k) for k in state.PENDING_MAP)
+    except Exception:
+        return False
+
+
 def on_transform_llm_output(response_text=None, session_id=None, **kwargs):
     """Fired once per turn with the agent's FINAL answer (after the tool loop).
 
@@ -86,6 +102,22 @@ def on_transform_llm_output(response_text=None, session_id=None, **kwargs):
     if not draft or epoch is None:
         return None  # not a turn-taking speak turn → leave Hermes alone
     chat = _chat_for_session(sid)
+    # A follow-up that arrived mid-turn gets merged into THIS turn's context, but
+    # the epoch above was bound at turn start — the service would drop the reply
+    # as superseded even though it answers the newest message. Stamp with the
+    # chat's latest epoch instead, unless a QUEUED follow-up turn exists (then
+    # the newest epoch belongs to its answer, not ours).
+    # ponytail: this is decidedly hacky — we infer "merged vs queued" by peeking
+    # at a live ref to the gateway's private pending_messages dict (PENDING_MAP)
+    # and correct the epoch after the fact, instead of the turn knowing what it
+    # actually consumed. Works, but rests on host internals. Worth a refactor
+    # someday: either the service accepts respond(claim_latest=true) and
+    # arbitrates atomically, or Hermes exposes "messages consumed by this turn"
+    # so the anchor/epoch can be bound correctly at the source.
+    latest = state.LATEST_EPOCH_BY_CHAT.get(chat or "")
+    if latest is not None and latest != epoch and not _queued_follow_up(chat):
+        _log.info("tt transform: epoch %s → %s (follow-up merged into this turn)", epoch, latest)
+        epoch = latest
     if chat:
         _suppress_answer(chat, draft)  # drop the send whose content matches this answer
     _log.info("tt transform: session=%s chat=%s mid=%s epoch=%s → naturalize + suppress raw send | %r",

--- a/turn_taking/hooks.py
+++ b/turn_taking/hooks.py
@@ -78,7 +78,12 @@ def _queued_follow_up(chat: str) -> bool:
     if not chat or not state.PENDING_MAP:
         return False
     try:
-        return any(chat in str(k) for k in state.PENDING_MAP)
+        # Session keys embed the chat id as a ':'-separated segment
+        # (gateway/session.py build_session_key: "{ns}:{platform}:dm:{chat_id}",
+        # group/thread variants likewise). Exact-segment match — a substring
+        # test would false-positive on numeric ids ("123" ⊂ "…:1234") and skip
+        # the re-stamp, silently reintroducing the dropped-reply bug.
+        return any(chat in str(k).split(":") for k in state.PENDING_MAP)
     except Exception:
         return False
 

--- a/turn_taking/patching.py
+++ b/turn_taking/patching.py
@@ -45,6 +45,21 @@ async def _annotate_mentions(adapter: Any, event: Any) -> None:
     if not text:
         return
     original = text
+    # Discord: resolve <@id>/<@!id> via the message's own resolved mentions —
+    # the adapter has no _bot_user_id/_resolve_user_name/_mention_patterns
+    # surface, but discord.py hands us every mentioned Member on the raw message.
+    d_mentions = getattr(getattr(event, "raw_message", None), "mentions", None)
+    d_self = getattr(getattr(adapter, "_client", None), "user", None)
+    if d_mentions:
+        for m in d_mentions:
+            try:
+                if d_self is not None and m.id == d_self.id:
+                    repl = "@you"
+                else:
+                    repl = "@" + (getattr(m, "display_name", None) or getattr(m, "name", "") or str(m.id))
+                text = text.replace(f"<@{m.id}>", repl).replace(f"<@!{m.id}>", repl)
+            except Exception as e:
+                _log.debug("tt: discord mention resolve failed: %s", e)
     # Slack: <@id> tokens (bot id + async display-name resolver).
     bot_id = getattr(adapter, "_bot_user_id", None)
     resolver = getattr(adapter, "_resolve_user_name", None)
@@ -75,6 +90,7 @@ async def _annotate_mentions(adapter: Any, event: Any) -> None:
             _log.debug("tt: mention pattern sub failed: %s", e)
     if text != original:
         event._tt_content = text
+        _log.info("tt mentions: %r → %r", original[:80], text[:80])
 
 
 _reply_anchor_patched = False  # idempotency for _patch__reply_anchor_for_event
@@ -123,6 +139,7 @@ def _platform_adapter_classes() -> list:
         ("whatsapp", "WhatsAppAdapter"),
         ("telegram", "TelegramAdapter"),
         ("slack", "SlackAdapter"),
+        ("discord", "DiscordAdapter"),
     ):
         try:
             classes.append(_real_adapter_class(platform, class_name))
@@ -402,6 +419,65 @@ def _patch_slack_handle_message() -> bool:
     return True
 
 
+# ── Discord gate: route handle_message through the turn-taking gate ───────────
+def _patch_discord_handle_message() -> bool:
+    """Gate Discord events that bypass the text queue, mirroring Telegram's patch.
+
+    Discord's ``_handle_message`` sends only live plain text (with batching
+    enabled) through ``_enqueue_text_event`` (the gate); media/attachments,
+    recovered historical messages, and ALL text when ``text_batch_delay_seconds``
+    is 0 dispatch straight to ``handle_message``. Wrapping it routes those through
+    ``_handle_inbound``; the genuine handler is kept in ``state.ORIG_HANDLE`` so a
+    "speak" turn dispatches via it instead of recursing. Idempotent.
+    """
+    try:
+        DiscordAdapter = _real_adapter_class("discord", "DiscordAdapter")
+    except Exception as e:
+        _log.warning("turn-taking: cannot patch Discord gate (no DiscordAdapter): %s", e)
+        return False
+    if getattr(DiscordAdapter.handle_message, "_tt_patched", False):
+        return False
+    _orig = DiscordAdapter.handle_message  # inherited from base; genuine handler
+    state.ORIG_HANDLE[DiscordAdapter] = _orig
+
+    async def handle_message(self, event):
+        await _handle_inbound(self, event)
+
+    handle_message._tt_patched = True  # type: ignore[attr-defined]
+    DiscordAdapter.handle_message = handle_message
+    return True
+
+
+# ── Discord host-typing mute: typing only during paced delivery ───────────────
+def _patch_discord_send_typing() -> bool:
+    """Mute the HOST's typing indicator on Discord; delivery keeps the real one.
+
+    The gateway starts ``send_typing`` when a turn dispatches and Discord's
+    implementation is a persistent 12s refresh loop — so the bot shows
+    "typing…" for the whole think time (a 2-minute tool-using turn = 2 minutes
+    of typing). Humalike's model is typing only while a bubble is being
+    "typed" (service-paced). Replace ``send_typing`` with a no-op and stash the
+    genuine one in ``state.ORIG_SEND_TYPING`` for delivery._forward_typing.
+    ``stop_typing`` stays genuine (stopping a never-started loop is a no-op).
+    Idempotent.
+    """
+    try:
+        DiscordAdapter = _real_adapter_class("discord", "DiscordAdapter")
+    except Exception as e:
+        _log.warning("turn-taking: cannot mute Discord host typing (no DiscordAdapter): %s", e)
+        return False
+    if getattr(DiscordAdapter.send_typing, "_tt_patched", False):
+        return False
+    state.ORIG_SEND_TYPING[DiscordAdapter] = DiscordAdapter.send_typing
+
+    async def send_typing(self, chat_id, metadata=None):
+        return None  # host think-time typing muted; delivery uses the original
+
+    send_typing._tt_patched = True  # type: ignore[attr-defined]
+    DiscordAdapter.send_typing = send_typing
+    return True
+
+
 # ── Group observation gate: let turn-taking jump into unmentioned chatter ──────
 async def _handle_observed_group(self: Any, event: Any, replay: Callable[[], Any]) -> None:
     """Gate one unmentioned group message: dispatch on an explicit "speak",
@@ -574,6 +650,7 @@ def _patch_merge_pending_message_event() -> bool:
         return False
 
     def _merge(pending_messages, session_key, event, *, merge_text=False):
+        state.PENDING_MAP = pending_messages  # live ref for hooks._queued_follow_up
         existing = pending_messages.get(session_key)
         orig(pending_messages, session_key, event, merge_text=merge_text)
         # A text follow-up merged INTO the existing pending turn (same object kept,

--- a/turn_taking/patching.py
+++ b/turn_taking/patching.py
@@ -276,7 +276,12 @@ def _patch__enqueue_text_event() -> bool:
     """Replace each adapter's ``_enqueue_text_event``: gate each message instead
     of Hermes's merge-debounce. Patches every importable adapter class (the gate is
     platform-agnostic — it duck-types the event). Idempotent. Returns True if any
-    class was patched."""
+    class was patched.
+
+    Note: on Discord this also bypasses the host's client-side split-message
+    batching (a >2000-char message Discord split into chunks arrives as separate
+    gated turns instead of one merged text) — consistent with the plugin's
+    gate-each-message model, and rare for real users."""
     patched_any = False
     for cls in _platform_adapter_classes():
         orig = getattr(cls, "_enqueue_text_event", None)

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -280,14 +280,18 @@ def _to_messages(events: list) -> list[Dict[str, Any]]:
         # resolved to @you / @Name; fall back to the raw text when it's absent.
         content = (getattr(ev, "_tt_content", None) or getattr(ev, "text", "") or "").strip()
         mtype = getattr(getattr(ev, "message_type", None), "value", "") or ""
-        # Discord fills captionless media with a host placeholder sentence instead
-        # of empty text; treat it as empty so the [image]/[media] branch applies
-        # and the service transcript isn't polluted with a meta-note.
-        if content == "(The user sent a message with no text content)":
-            content = ""
         # WhatsApp only emits "text" or a media type (commands arrive as text), so
         # anything else — or any attached media — marks this as a media message.
         has_media = bool(getattr(ev, "media_urls", None)) or mtype not in ("", "text", "command")
+        # Discord fills captionless media with a host placeholder sentence instead
+        # of empty text; treat it as empty so the [image]/[media] branch applies
+        # and the service transcript isn't polluted with a meta-note. Gated on
+        # has_media so a user who literally types this sentence keeps their text.
+        # The literal is hardcoded (not localized) in THREE host sites — keep in
+        # sync: plugins/platforms/discord/adapter.py:7555, gateway/run.py:16972,
+        # gateway/run.py:17017.
+        if has_media and content == "(The user sent a message with no text content)":
+            content = ""
         if not content:
             if not has_media:
                 continue

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -280,6 +280,11 @@ def _to_messages(events: list) -> list[Dict[str, Any]]:
         # resolved to @you / @Name; fall back to the raw text when it's absent.
         content = (getattr(ev, "_tt_content", None) or getattr(ev, "text", "") or "").strip()
         mtype = getattr(getattr(ev, "message_type", None), "value", "") or ""
+        # Discord fills captionless media with a host placeholder sentence instead
+        # of empty text; treat it as empty so the [image]/[media] branch applies
+        # and the service transcript isn't polluted with a meta-note.
+        if content == "(The user sent a message with no text content)":
+            content = ""
         # WhatsApp only emits "text" or a media type (commands arrive as text), so
         # anything else — or any attached media — marks this as a media message.
         has_media = bool(getattr(ev, "media_urls", None)) or mtype not in ("", "text", "command")

--- a/turn_taking/state.py
+++ b/turn_taking/state.py
@@ -35,6 +35,21 @@ ORIG_SEND: Dict[type, Callable] = {}
 # falls back to the adapter's own (unpatched) handle_message.
 ORIG_HANDLE: Dict[type, Callable] = {}
 
+# Genuine send_typing per adapter class whose host typing is muted (Discord):
+# the host's think-time indicator is suppressed; delivery's paced typing calls
+# the original through here.
+ORIG_SEND_TYPING: Dict[type, Callable] = {}
+
+# Latest speak-epoch the service assigned per chat (written at decide). Lets the
+# transform hook stamp a merged turn's respond with the epoch of the newest
+# message it absorbed, instead of the one bound at turn start.
+LATEST_EPOCH_BY_CHAT: Dict[str, int] = {}
+
+# Live reference to the gateway's pending_messages map (captured by the
+# merge_pending_message_event wrapper). A pending entry for a chat means a
+# QUEUED follow-up turn exists — its answer owns the newest epoch, ours doesn't.
+PENDING_MAP: Optional[Dict] = None
+
 # The most recent adapter instance seen by the inbound gate. Fallback for
 # notify.py when ROUTES is empty (service dead from startup → no thread was
 # ever opened, but an alert still needs a live adapter to reach the gateway).


### PR DESCRIPTION
Re-lands the five commits from #18, which was merged 12 seconds after its base #17 went into main — so it landed on the already-merged `feat/config-hygiene` branch and never reached `main`. Cherry-picked onto current main (one conflict in `hooks.py` resolved: the new social-memory hooks and this branch's `_queued_follow_up` now coexist), full suite green (91/91).

See #18 for the full description, live-testing notes, and the two-lane review (findings addressed in the last commit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Discord support for turn-taking, including message gating, mention resolution (`@you` for the bot), and slash-command compatibility.
  - Discord typing indicators now start/stop in sync with response delivery.
  - Improved handling of Discord captionless media placeholders and threaded/rapid follow-ups.
- **Bug Fixes**
  - Improved merged-turn/epoch handling to prevent newer responses being discarded or mis-ordered.
- **Documentation**
  - Expanded Discord setup instructions, required intents, and configuration/environment guidance, plus Discord behavior notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->