### PR TITLE
fix: resolve config.yaml/SOUL.md from the active profile home

### DIFF
--- a/_config.py
+++ b/_config.py
@@ -11,14 +11,19 @@ DEFAULT_API = "https://api.humalike.com"
 def _getenv(name: str, default: str = "") -> str:
     """Env var, honoring Hermes's per-profile secret scope when one is in
     effect (multiplexed turns read the profile's .env, never another
-    profile's os.environ). Outside Hermes or single-profile → plain getenv."""
+    profile's os.environ). Outside Hermes → plain getenv. An unscoped lookup
+    in a multiplexed gateway (get_secret's fail-closed sentinel) returns the
+    default — NEVER os.environ, which may hold another profile's key; an
+    empty key just means "service off" to every caller here."""
     try:
-        from agent.secret_scope import get_secret
-
-        val = get_secret(name, default)
-        return val if val is not None else default
-    except Exception:
+        from agent.secret_scope import UnscopedSecretError, get_secret
+    except ImportError:
         return os.getenv(name, default)
+    try:
+        val = get_secret(name, default)
+    except UnscopedSecretError:
+        return default
+    return val if val is not None else default
 
 
 def service_url() -> str:

--- a/_config.py
+++ b/_config.py
@@ -8,13 +8,26 @@ import os
 DEFAULT_API = "https://api.humalike.com"
 
 
+def _getenv(name: str, default: str = "") -> str:
+    """Env var, honoring Hermes's per-profile secret scope when one is in
+    effect (multiplexed turns read the profile's .env, never another
+    profile's os.environ). Outside Hermes or single-profile → plain getenv."""
+    try:
+        from agent.secret_scope import get_secret
+
+        val = get_secret(name, default)
+        return val if val is not None else default
+    except Exception:
+        return os.getenv(name, default)
+
+
 def service_url() -> str:
     """Base URL for all Humalike calls (``HUMALIKE_API_URL``). Defaults to the
     public API so a fresh install needs zero env setup; set it EMPTY
     (``HUMALIKE_API_URL=``) to explicitly disable turn-taking."""
-    return os.getenv("HUMALIKE_API_URL", DEFAULT_API).rstrip("/")
+    return _getenv("HUMALIKE_API_URL", DEFAULT_API).rstrip("/")
 
 
 def api_key() -> str:
     """API key for all Humalike calls, sent as ``Authorization: Bearer`` (``HUMALIKE_API_KEY``)."""
-    return os.getenv("HUMALIKE_API_KEY", "")
+    return _getenv("HUMALIKE_API_KEY", "")

--- a/soul/__init__.py
+++ b/soul/__init__.py
@@ -25,8 +25,35 @@ import httpx
 
 _log = logging.getLogger(__name__)
 
-_HERMES_CONFIG = Path.home() / ".hermes" / "config.yaml"
-_AUTO_MARKER = _HERMES_CONFIG.with_name(".soul_auto_enhanced")  # one-shot guard
+# HERMES_HOME-aware fallback, kept as a module attr so tests can repoint it.
+_HERMES_HOME = Path(os.getenv("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def _hermes_home() -> Path:
+    """The ACTIVE hermes home — the context-local profile override when profile
+    routing has one in scope (per-turn, e.g. /soul enhance runs inside the
+    gateway's _profile_runtime_scope), else the process default. Duplicated from
+    turn_taking.service on purpose: this module stays import-free of the plugin."""
+    try:
+        from hermes_constants import get_hermes_home_override
+
+        override = get_hermes_home_override()
+        if override:
+            return Path(override)
+    except Exception:
+        pass
+    return _HERMES_HOME
+
+
+def _hermes_config() -> Path:
+    return _hermes_home() / "config.yaml"
+
+
+def _auto_marker() -> Path:
+    return _hermes_home() / ".soul_auto_enhanced"  # one-shot guard, per profile
+
+
+
 ENHANCE_PATH = "/v1/personas/actions/enhance"
 ENHANCEMENT_REPO = "/v1/personas/repositories/Enhancement/by-id/{}"
 DEFAULT_API = "https://api.humalike.com"
@@ -43,7 +70,7 @@ def _cfg() -> Dict[str, Any]:
     try:
         import yaml
 
-        cfg = yaml.safe_load(_HERMES_CONFIG.read_text()) or {}
+        cfg = yaml.safe_load(_hermes_config().read_text()) or {}
         return cfg.get("turn_taking") or {}
     except Exception:
         return {}
@@ -64,7 +91,7 @@ def _soul_path() -> Path:
     plugin's _build_system_prompt_for_turn_taking() actually reads at runtime). Override via env or
     ``turn_taking.soul_path`` in config.yaml (e.g. point it at docker/SOUL.md)."""
     p = os.getenv("HERMES_SOUL_PATH") or str(_cfg().get("soul_path") or "")
-    return Path(p).expanduser() if p else _HERMES_CONFIG.with_name("SOUL.md")
+    return Path(p).expanduser() if p else _hermes_home() / "SOUL.md"
 
 
 # ── SOUL.md parsing ───────────────────────────────────────────────────────────
@@ -223,13 +250,20 @@ def maybe_auto_enhance() -> None:
     """Fire the one-shot auto-enhance on first startup, in a background thread so it
     never blocks gateway boot (enhance polls for minutes). Marker-guarded and a no-op
     once done. ponytail: delete ~/.hermes/.soul_auto_enhanced to force a re-run."""
-    if not _auto_enabled() or _AUTO_MARKER.exists():
+    if not _auto_enabled() or _auto_marker().exists():
         return
+
+    # Snapshot the context NOW: the background thread outlives any context-local
+    # profile scope, so home-dependent paths (SOUL.md, the marker) must resolve
+    # under the scope that scheduled us, not the thread's empty context.
+    import contextvars
+
+    ctx = contextvars.copy_context()
 
     def _run() -> None:
         try:
-            if asyncio.run(_auto_enhance()):
-                _AUTO_MARKER.write_text("")  # succeeded → never auto-run again
+            if ctx.run(asyncio.run, _auto_enhance()):
+                ctx.run(_auto_marker).write_text("")  # succeeded → never auto-run again
         except Exception as e:
             _log.warning("soul: auto-enhance thread errored: %s", e)
 

--- a/soul/__init__.py
+++ b/soul/__init__.py
@@ -78,14 +78,17 @@ def _cfg() -> Dict[str, Any]:
 
 def _getenv(name: str, default: str = "") -> str:
     """Env var, honoring Hermes's per-profile secret scope (mirrors _config._getenv;
-    duplicated because this module stays import-free of the plugin)."""
+    duplicated because this module stays import-free of the plugin). Unscoped
+    lookup under multiplexing → default, never os.environ (fail closed)."""
     try:
-        from agent.secret_scope import get_secret
-
-        val = get_secret(name, default)
-        return val if val is not None else default
-    except Exception:
+        from agent.secret_scope import UnscopedSecretError, get_secret
+    except ImportError:
         return os.getenv(name, default)
+    try:
+        val = get_secret(name, default)
+    except UnscopedSecretError:
+        return default
+    return val if val is not None else default
 
 
 def _api_url() -> str:

--- a/soul/__init__.py
+++ b/soul/__init__.py
@@ -36,12 +36,12 @@ def _hermes_home() -> Path:
     turn_taking.service on purpose: this module stays import-free of the plugin."""
     try:
         from hermes_constants import get_hermes_home_override
+    except ImportError:
+        return _HERMES_HOME
 
-        override = get_hermes_home_override()
-        if override:
-            return Path(override)
-    except Exception:
-        pass
+    override = get_hermes_home_override()
+    if override:
+        return Path(override)
     return _HERMES_HOME
 
 

--- a/soul/__init__.py
+++ b/soul/__init__.py
@@ -76,14 +76,26 @@ def _cfg() -> Dict[str, Any]:
         return {}
 
 
+def _getenv(name: str, default: str = "") -> str:
+    """Env var, honoring Hermes's per-profile secret scope (mirrors _config._getenv;
+    duplicated because this module stays import-free of the plugin)."""
+    try:
+        from agent.secret_scope import get_secret
+
+        val = get_secret(name, default)
+        return val if val is not None else default
+    except Exception:
+        return os.getenv(name, default)
+
+
 def _api_url() -> str:
-    url = os.getenv("HUMALIKE_API_URL") or DEFAULT_API
+    url = _getenv("HUMALIKE_API_URL") or DEFAULT_API
     return url.rstrip("/")
 
 
 def _api_key() -> str:
     # Same key as the turn-taking service unless a personas-specific one is set.
-    return os.getenv("HUMALIKE_API_KEY") or os.getenv("TURN_TAKING_API_KEY", "")
+    return _getenv("HUMALIKE_API_KEY") or _getenv("TURN_TAKING_API_KEY")
 
 
 def _soul_path() -> Path:

--- a/tests/test_agent_name.py
+++ b/tests/test_agent_name.py
@@ -82,7 +82,7 @@ def test_agent_name_env_config_then_hardcoded_default(tmp_path=None):
     # ~/.hermes/config.yaml, then falls back to the hardcoded "Hermes" (the
     # product name — every un-renamed install gets the fix with zero config).
     # Exercise all three without loading all of core.py's imports: point its
-    # _HERMES_CONFIG at a temp file.
+    # _hermes_config() at a temp file.
     import tempfile
 
     core = _load_core()
@@ -92,12 +92,12 @@ def test_agent_name_env_config_then_hardcoded_default(tmp_path=None):
     with tempfile.TemporaryDirectory() as d:
         cfg = Path(d) / "config.yaml"
         cfg.write_text("agent:\n  name: Viktor\n")
-        with patch.object(core, "_HERMES_CONFIG", cfg):
+        with patch.object(core, "_hermes_config", lambda: cfg):
             assert core._agent_name() == "Viktor"
         cfg.write_text("agent: {}\n")
-        with patch.object(core, "_HERMES_CONFIG", cfg):
+        with patch.object(core, "_hermes_config", lambda: cfg):
             assert core._agent_name() == "Hermes"
-    with patch.object(core, "_HERMES_CONFIG", Path("/nonexistent/config.yaml")):
+    with patch.object(core, "_hermes_config", lambda: Path("/nonexistent/config.yaml")):
         assert core._agent_name() == "Hermes"
 
 

--- a/turn_taking/core.py
+++ b/turn_taking/core.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, Optional
 from . import state
 from .. import social_learning
 from .delivery import _ensure_thread
-from .service import _HERMES_CONFIG, _to_messages, respond, submit_messages
+from .service import _hermes_config, _to_messages, respond, submit_messages
 
 _log = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ def _build_system_prompt_for_turn_taking(adapter: Any = None, session_id: Option
     # silently skipped if it moves.
     parts: list[str] = []
     try:
-        soul = _HERMES_CONFIG.with_name("SOUL.md").read_text().strip()
+        soul = _hermes_config().with_name("SOUL.md").read_text().strip()
         if soul:
             parts.append(soul)
     except Exception:
@@ -67,7 +67,7 @@ def _build_system_prompt_for_turn_taking(adapter: Any = None, session_id: Option
     try:
         import yaml
 
-        cfg = yaml.safe_load(_HERMES_CONFIG.read_text()) or {}
+        cfg = yaml.safe_load(_hermes_config().read_text()) or {}
         return str((cfg.get("agent") or {}).get("system_prompt", "")).strip() or None
     except Exception:
         return None
@@ -91,7 +91,7 @@ def _agent_name() -> str:
     try:
         import yaml
 
-        cfg = yaml.safe_load(_HERMES_CONFIG.read_text()) or {}
+        cfg = yaml.safe_load(_hermes_config().read_text()) or {}
         return str((cfg.get("agent") or {}).get("name", "")).strip() or DEFAULT_AGENT_NAME
     except Exception:
         return DEFAULT_AGENT_NAME

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -33,8 +33,30 @@ RESPOND_PATH = "/v1/turn-taking/actions/respond"
 # SOUL.md, the most useful signal for decide/naturalize.
 _SYSTEM_PROMPT_CAP = 100000
 
-# ~/.hermes/config.yaml — used by core.py to read SOUL.md + the agent system prompt.
-_HERMES_CONFIG = Path.home() / ".hermes" / "config.yaml"
+# config.yaml in the process-level hermes home (HERMES_HOME-aware) — used by
+# core.py to read SOUL.md + the agent system prompt. Kept as a module attr so
+# tests can point it at a temp file.
+_HERMES_CONFIG = Path(os.getenv("HERMES_HOME") or Path.home() / ".hermes") / "config.yaml"
+
+
+def _hermes_config() -> Path:
+    """config.yaml of the ACTIVE hermes home.
+
+    Profile routing serves several profiles from one gateway process, scoping
+    each turn with a context-local home override (``set_hermes_home_override``)
+    that propagates into the agent worker thread — so reading it here makes
+    every config/SOUL.md read per-profile. No override (single-profile
+    gateways, tests) falls back to the module default above.
+    """
+    try:
+        from hermes_constants import get_hermes_home_override
+
+        override = get_hermes_home_override()
+        if override:
+            return Path(override) / "config.yaml"
+    except Exception:
+        pass
+    return _HERMES_CONFIG
 
 
 # ── Config + auth ─────────────────────────────────────────────────────────────
@@ -73,7 +95,7 @@ def _pacing() -> Dict[str, Any]:
     try:
         import yaml
 
-        cfg = yaml.safe_load(_HERMES_CONFIG.read_text()) or {}
+        cfg = yaml.safe_load(_hermes_config().read_text()) or {}
         pacing = (cfg.get("turn_taking") or {}).get("pacing")
         if isinstance(pacing, dict) and pacing:
             return dict(pacing)

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -50,12 +50,12 @@ def _hermes_config() -> Path:
     """
     try:
         from hermes_constants import get_hermes_home_override
+    except ImportError:
+        return _HERMES_CONFIG
 
-        override = get_hermes_home_override()
-        if override:
-            return Path(override) / "config.yaml"
-    except Exception:
-        pass
+    override = get_hermes_home_override()
+    if override:
+        return Path(override) / "config.yaml"
     return _HERMES_CONFIG
 
 

--- a/turn_taking/service.py
+++ b/turn_taking/service.py
@@ -149,7 +149,7 @@ def _memory_bank_id() -> str:
     name) so it remembers people across ALL its channels, not per channel.
     ``HUMALIKE_MEMORY_BANK_ID`` overrides — e.g. to run several distinct agents,
     each with its own bank."""
-    override = os.getenv("HUMALIKE_MEMORY_BANK_ID", "").strip()
+    override = _config._getenv("HUMALIKE_MEMORY_BANK_ID").strip()
     if override:
         return override
     # Deferred import: core imports this module, so import at call time to avoid


### PR DESCRIPTION
## Problem

The plugin read all its configuration from hardcoded process-global locations, so hermes-agent's profile-based routing (one gateway serving multiple isolated profiles under `~/.hermes/profiles/<name>/`) got the root profile's everything:

- `turn_taking` + `soul` read `~/.hermes/config.yaml` / `SOUL.md` via a `Path.home()` constant (`HERMES_HOME` was ignored too);
- `HUMALIKE_API_URL` / `HUMALIKE_API_KEY` / `HUMALIKE_MEMORY_BANK_ID` came from `os.environ`, which never holds per-profile `.env` secrets under multiplexing.

## Fix — three commits, one pattern each

**1. `turn_taking`: profile-aware config/SOUL.md.** `_hermes_config()` in `service.py`, used at every read site: the context-local profile-home override (`hermes_constants.get_hermes_home_override` — set per routed turn by the gateway's `_profile_runtime_scope`, propagated into the worker thread) → else the module default, now `HERMES_HOME`-aware. Config was already read per call, so resolution is per-turn with no plumbing. Covers pacing, `agent.name`, `agent.system_prompt`, SOUL.md — and makes the social-memory bank per-profile too (its fallback is `agent.name`).

**2. `soul`: same seam.** Local `_hermes_home()` (module deliberately stays import-free of the plugin): `/soul enhance`, its config reads, the default SOUL.md path, and the `.soul_auto_enhanced` one-shot marker are all per-profile. The auto-enhance background thread runs under a `contextvars.copy_context()` snapshot so paths resolve under the scope that scheduled it. Note: the marker moving into profile homes means existing named-profile installs auto-enhance once more on next boot (marker-guarded, fail-open).

**3. Credentials: per-profile secret scope.** `_config._getenv()` routes `HUMALIKE_API_URL` / `HUMALIKE_API_KEY` (and `service._memory_bank_id`'s env override; `soul` mirrors it) through `agent.secret_scope.get_secret` when importable — scoped turns read the profile's `.env`, never another profile's `os.environ`. Unscoped / outside Hermes falls back to plain `getenv`.

Single-profile gateways never enter these scopes, so behavior there is byte-identical. Every seam fails open to the legacy path.

**Out of scope:** the `state.py` runtime dicts stay process-global — they're keyed by `chat_id`/`session_id`/`message_id` and routing assigns whole chats to profiles, so entries can't collide across profiles.

## Tests

- `tests/test_agent_name.py` updated to patch `_hermes_config` (was the removed constant); `test_service_pacing.py` / `test_soul.py` / `test_misconfig.py` unchanged and passing (standalone runners).
- Smoke-checked: home override → `<profile>/config.yaml`, `SOUL.md`, marker (incl. propagation into the copied-context thread); secret scope → profile key inside scope, process env outside.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes home resolution so config-derived settings are consistent across persona/system prompt, agent-name resolution, pacing, and related reads/writes, including profile-specific overrides.
  * `SOUL.md` access and auto-enhancement updates now reliably use the resolved Hermes home, with safer context handling during background execution.
  * Environment-driven settings now consistently apply intended override/fallback behavior, including secret-scoped reads and memory bank ID handling.
* **Tests**
  * Updated agent-name configuration/environment tests to match the revised Hermes config accessor and patching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->